### PR TITLE
fix(Form): Removed empty Form.scss to prevent sass-loader from failing with Webpack2

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -1,10 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { Base } from 'bw-axiom';
 
-if (__INCLUDE_CSS__) {
-  require('./Form.scss');
-}
-
 export default class Form extends Component {
   static propTypes = {
     children: PropTypes.node,


### PR DESCRIPTION
I'm currently working on adding Axiom to a new project which is using Webpack 2. During the setup of the configuration I came across an issue which seems to be related to Webpack 2 and the sass-loader plugin: It can't handle empty .scss files.
As the `Form.scss` is empty anyways I don't see a need to keep this file. 