### PR TITLE
feat(TableCell): add expand prop so table columns can be stretched

### DIFF
--- a/src/components/table/Table.scss
+++ b/src/components/table/Table.scss
@@ -17,6 +17,10 @@ $table-padding-horizontal: $spacing-grid-size * 8;
   padding-right: $table-padding-horizontal;
 }
 
+.ax-table__cell--grow {
+  width: 100%;
+}
+
 .ax-table__head {
   .ax-table__cell {
     padding-top: $table-padding-vertical-small;

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -1,19 +1,30 @@
 import React, { Component, PropTypes } from 'react';
 import { Base } from 'bw-axiom';
+import classnames from 'classnames';
 
 export default class TableCell extends Component {
   static propTypes = {
     children: PropTypes.node,
+    grow: PropTypes.boolean,
+  };
+
+  static defaultProps = {
+    grow: false,
   };
 
   render() {
     const {
       children,
+      grow,
       ...rest
     } = this.props;
 
+    const classes = classnames('ax-table__cell', {
+      'ax-table__cell--grow': grow,
+    });
+
     return (
-      <Base { ...rest } Component="td" className="ax-table__cell">
+      <Base { ...rest } Component="td" className={ classes }>
         { children }
       </Base>
     );

--- a/src/components/table/TableCell.test.js
+++ b/src/components/table/TableCell.test.js
@@ -2,9 +2,9 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { TableCell } from 'bw-axiom';
 
-function getComponent() {
+function getComponent(props = {}) {
   return renderer.create(
-    <TableCell>
+    <TableCell { ...props }>
       123456
     </TableCell>
   );
@@ -13,6 +13,12 @@ function getComponent() {
 describe('TableBody', () => {
   it('renders', () => {
     const component = getComponent();
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders with grow', () => {
+    const component = getComponent({ grow: true });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/table/__snapshots__/TableCell.test.js.snap
+++ b/src/components/table/__snapshots__/TableCell.test.js.snap
@@ -7,3 +7,11 @@ exports[`TableBody renders 1`] = `
   123456
 </td>
 `;
+
+exports[`TableBody renders with grow 1`] = `
+<td
+  className="ax-table__cell ax-table__cell--grow"
+>
+  123456
+</td>
+`;

--- a/src/components/table/example/grow.js
+++ b/src/components/table/example/grow.js
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import { Example, Snippet } from 'style-guide';
+import { Table, TableHead, TableRow, TableCell, TableBody, Strong } from 'bw-axiom';
+
+export default class TableExample extends Component {
+  render() {
+    return (
+      <Example name="Grow">
+        <Snippet>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>
+                  <Strong snippetIgnore={ true }>Id</Strong>
+                </TableCell>
+                <TableCell>
+                  <Strong snippetIgnore={ true }>First name</Strong>
+                </TableCell>
+                <TableCell>
+                  <Strong snippetIgnore={ true }>Last name</Strong>
+                </TableCell>
+                <TableCell>
+                  <Strong snippetIgnore={ true }>City</Strong>
+                </TableCell>
+                <TableCell grow={ true }>
+                  <Strong snippetIgnore={ true }>Birthday</Strong>
+                </TableCell>
+                <TableCell>
+                  <Strong snippetIgnore={ true }>Enabled</Strong>
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell>
+                  1
+                </TableCell>
+                <TableCell>
+                  Max
+                </TableCell>
+                <TableCell>
+                  Mustermann
+                </TableCell>
+                <TableCell>
+                  Stuttgart
+                </TableCell>
+                <TableCell>
+                  17-Apr-1990
+                </TableCell>
+                <TableCell>
+                  Enabled
+                </TableCell>
+              </TableRow>
+              <TableRow snippetSkip={ true }>
+                <TableCell>
+                  26
+                </TableCell>
+                <TableCell>
+                  John
+                </TableCell>
+                <TableCell>
+                  Doe
+                </TableCell>
+                <TableCell>
+                  Brighton
+                </TableCell>
+                <TableCell>
+                  01-May-1985
+                </TableCell>
+                <TableCell>
+                  Disabled
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </Snippet>
+      </Example>
+    );
+  }
+}

--- a/src/components/table/example/index.js
+++ b/src/components/table/example/index.js
@@ -1,4 +1,5 @@
 module.exports = [
   require('./table').default,
   require('./compact').default,
+  require('./grow').default,
 ];


### PR DESCRIPTION
This change is required to meet a design requirement on an axiom table. As far as I'm aware this is the way to achieve an expanded column in a table, but open to other suggestions if anyone has them. Thanks!