### PR TITLE
fix(PostCSS): Ignore PostCSS config from NPM

### DIFF
--- a/.jest.json
+++ b/.jest.json
@@ -4,8 +4,5 @@
     "^bw-axiom$": "<rootDir>/src/index.js"
   },
   "moduleFileExtensions": ["js"],
-  "moduleDirectories": ["node_modules"],
-  "globals": {
-    "__INCLUDE_CSS__": false
-  }
+  "moduleDirectories": ["node_modules"]
 }

--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,7 @@ src
 static
 style-guide
 test
+deploy_key.enc
 npm-debug.log
+postcss.config.js
 yarn-error.log


### PR DESCRIPTION
Cosmiconfig that PostCSS loader uses, looks for the nearest matching config from the file it's processing. It picks up Axiom's where it shouldn't, it's not needed in the NPM module so best to just ignore it when publishing. 