### PR TITLE
fix(ContextBox): Adds missing separators between ContextMenu

### DIFF
--- a/src/components/context/ContextBox.css
+++ b/src/components/context/ContextBox.css
@@ -8,20 +8,10 @@
 
 .ax-context-box--padding-small {
   padding: var(--cmp-context-padding-small);
-
-  & + .ax-context-box::before {
-    right: var(--cmp-context-padding-small);
-    left: var(--cmp-context-padding-small);
-  }
 }
 
 .ax-context-box--padding-large {
   padding: var(--cmp-context-padding-large);
-
-  & + .ax-context-box::before {
-    right: var(--cmp-context-padding-large);
-    left: var(--cmp-context-padding-large);
-  }
 }
 
 .ax-context-box + .ax-context-box::before {
@@ -30,6 +20,17 @@
   top: 0;
   border-bottom-width: var(--component-border-width);
   border-bottom-style: solid;
+}
+
+.ax-context-box--padding-small::before {
+  right: var(--cmp-context-padding-small);
+  left: var(--cmp-context-padding-small);
+}
+
+.ax-context-box--padding-none::before,
+.ax-context-box--padding-large::before {
+  right: var(--cmp-context-padding-large);
+  left: var(--cmp-context-padding-large);
 }
 
 .ax-context--dark .ax-context-box::before {

--- a/src/components/context/example/combinations.js
+++ b/src/components/context/example/combinations.js
@@ -56,18 +56,27 @@ export default class ContextTipExample extends Component {
               <Context position="top">
                 <ContextBox>
                   <Paragraph>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                    Duis at velit ut nisl eleifend volutpat.
+                    Menu combination
                   </Paragraph>
                 </ContextBox>
 
                 <ContextMenu>
                   <ContextMenuItem>
-                    Settings
+                    Group 1
                   </ContextMenuItem>
 
                   <ContextMenuItem>
-                    Help!
+                    Group 1
+                  </ContextMenuItem>
+                </ContextMenu>
+
+                <ContextMenu>
+                  <ContextMenuItem>
+                    Group 2
+                  </ContextMenuItem>
+
+                  <ContextMenuItem>
+                    Group 2
                   </ContextMenuItem>
                 </ContextMenu>
               </Context>


### PR DESCRIPTION
<img width="275" alt="screen shot 2017-04-13 at 15 27 08" src="https://cloud.githubusercontent.com/assets/7130591/25009214/de36a5e8-205d-11e7-9211-c961ad5fdc7b.png">
