### PR TITLE
fix(browser-support): Remove ES2015 methods from src code & babel-polyfill from styleguide

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "babel-core": "6.13.2",
     "babel-eslint": "^6.1.2",
     "babel-loader": "6.2.4",
-    "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-react": "^6.11.1",
     "babel-preset-react-hmre": "1.1.1",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,7 +3,8 @@ import { Children } from 'react';
 const isServer = typeof window === 'undefined';
 
 export function findComponent(components, Component) {
-  return Children.toArray(components).find(({ type }) => type === Component);
+  const arr = Children.toArray(components);
+  for (let i = 0; i < arr.length; i++) if (arr[i].type === Component) return arr[i];
 }
 
 export function getCSSVar(variable, context) {

--- a/style-guide/client.js
+++ b/style-guide/client.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 import { useRouterHistory, Router } from 'react-router';

--- a/style-guide/containers/Navigation.js
+++ b/style-guide/containers/Navigation.js
@@ -8,7 +8,7 @@ function buildItem({ props }, activePath, openPath, parentPath = '') {
   return {
     name: props.name,
     to: path,
-    isOpen: openPath.includes(path),
+    isOpen: openPath.indexOf(path) !== -1,
     isActive: path === activePath,
     children: Array.isArray(props.children)
       ? props.children.map((child) => buildItem(child, activePath, openPath, path))

--- a/style-guide/static.js
+++ b/style-guide/static.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 import { renderToString } from 'react-dom/server';

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,7 +905,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.13.0, babel-polyfill@^6.16.0, babel-polyfill@^6.9.0:
+babel-polyfill@^6.16.0, babel-polyfill@^6.9.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
   dependencies:


### PR DESCRIPTION
Axiom was broken in IE11 anywhere where `find` and `includes` weren't being polyfilled. We shouldn't assume users are polyfilling these methods and should stick to ES5 methods. Removind `babel-polyfill` allows us to more reliably test brower compatibility within older browsers 🎉 