### PR TITLE
fix(CSS): Moves an overflow that was added to known overflowing compo…

### DIFF
--- a/src/components/grid/Grid.css
+++ b/src/components/grid/Grid.css
@@ -8,10 +8,6 @@
   --cmp-grid-gutter-size-large: calc(var(--spacing-grid-size) * 8);
 }
 
-.ax-grid__container {
-  overflow: hidden;
-}
-
 .ax-grid {
   display: flex;
 }

--- a/src/components/layout/InlineGroup.css
+++ b/src/components/layout/InlineGroup.css
@@ -4,10 +4,6 @@
   --cmp-inline-spacing: calc(var(--spacing-grid-size) * 2);
 }
 
-.ax-inline-group {
-  overflow: hidden;
-}
-
 .ax-inline-group__spacer {
   margin-bottom: calc(var(--cmp-inline-spacing) * -1);
 

--- a/src/components/reveal/Reveal.css
+++ b/src/components/reveal/Reveal.css
@@ -9,6 +9,7 @@
 
 .ax-reveal__inner {
   transform: translateY(25%);
+  overflow: hidden;
   transition-property: transform;
   transition-duration: var(--transition-time-slow);
   transition-timing-function: var(--transition-function);


### PR DESCRIPTION
…nents.

Added because of an issue with the Reveal component. This caused further issues with clipping legitimate overflowing out of GridCells, so the overflow handling has been moved to Reveal component, where it was needed in the first place. 