### PR TITLE
fix(ChartTable): Collapsible behaviour

### DIFF
--- a/src/charts/chart-table/ChartTableRows.test.js
+++ b/src/charts/chart-table/ChartTableRows.test.js
@@ -1,51 +1,35 @@
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import renderer from 'react-test-renderer';
 import {
+  ChartTable,
   ChartTableRows,
   ChartTableRow,
   ChartTableLabel,
   ChartTableVisual,
 } from 'bw-axiom';
 
-class ContextProvider extends Component {
-  getChildContext () {
-    return this.props.context;
-  }
-  render () {
-    return this.props.children;
-  }
+function createNodeMock() {
+  return {
+    addEventListener: () => {},
+  };
 }
 
-ContextProvider.childContextTypes = {
-  setRowsCount: PropTypes.func.isRequired,
-};
-
-ContextProvider.propTypes = {
-  children: PropTypes.node,
-  context: PropTypes.object.isRequired,
-};
-
-function getComponent(props = {}, context) {
+function getComponent(props = {}) {
   return renderer.create(
-    <ContextProvider context={ context }>
+    <ChartTable>
       <ChartTableRows { ...props }>
         <ChartTableRow>
           <ChartTableLabel>Lorem</ChartTableLabel>
           <ChartTableVisual>Lorem</ChartTableVisual>
         </ChartTableRow>
       </ChartTableRows>
-    </ContextProvider>
-  );
+    </ChartTable>
+  , { createNodeMock });
 }
 
 describe('ChartTableRows', () => {
-  function setRowsCount () {}
-
   it('renders with defaultProps', () => {
-    const component = getComponent({}, {
-      setRowsCount,
-    });
+    const component = getComponent();
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/charts/chart-table/__snapshots__/ChartTableRows.test.js.snap
+++ b/src/charts/chart-table/__snapshots__/ChartTableRows.test.js.snap
@@ -2,37 +2,41 @@
 
 exports[`ChartTableRows renders with defaultProps 1`] = `
 <div
-  className="ax-chart-table__rows-container"
-  style={
-    Object {
-      "height": "auto",
-    }
-  }
+  className="ax-chart-table"
 >
-  <table
-    className="ax-chart-table__rows"
+  <div
+    className="ax-chart-table__rows-container"
+    style={
+      Object {
+        "height": null,
+      }
+    }
   >
-    <tbody>
-      <tr
-        className="ax-chart-table__row"
-      >
-        <td
-          className="ax-chart-table__cell ax-text--color-subtle"
-          style={
-            Object {
-              "width": undefined,
+    <table
+      className="ax-chart-table__rows"
+    >
+      <tbody>
+        <tr
+          className="ax-chart-table__row"
+        >
+          <td
+            className="ax-chart-table__cell ax-text--color-subtle"
+            style={
+              Object {
+                "width": "10rem",
+              }
             }
-          }
-        >
-          Lorem
-        </td>
-        <td
-          className="ax-chart-table__cell"
-        >
-          Lorem
-        </td>
-      </tr>
-    </tbody>
-  </table>
+          >
+            Lorem
+          </td>
+          <td
+            className="ax-chart-table__cell"
+          >
+            Lorem
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 `;

--- a/src/charts/dot-plot/example/dot-plot-table-collapsible.js
+++ b/src/charts/dot-plot/example/dot-plot-table-collapsible.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { Example, Snippet } from 'style-guide';
 import {
+  Button,
+  ButtonGroup,
   ChartKey,
   ChartKeyItem,
   ChartTable,
@@ -20,15 +22,42 @@ import {
 import { labels, data } from './data';
 
 export default class DotPlotExample extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      nextRowCount: 8,
+      rowData: data.slice(0, 7),
+    };
+  }
+
+  addRow() {
+    this.setState((state) => ({
+      nextRowCount: state.nextRowCount + 1,
+      rowData: data.slice(0, state.nextRowCount),
+    }));
+  }
+
   render() {
+    const { rowData } = this.state;
+
     return (
-      <Example name="DotPlot inside ChartTable">
+      <Example name="DotPlot inside collapsible ChartTable">
+        <ButtonGroup>
+          <Button
+              disabled={ rowData.length === data.length }
+              onClick={ () => this.addRow() }>
+            Add another row of data
+          </Button>
+        </ButtonGroup>
+
         <Snippet>
           <ChartTable
+              collapsedVisibleRowCount={ 6 }
+              expandButtonSuffix="Categories"
               labelColumnWidth="11rem">
-            <ChartTableGrid>
+            <ChartTableGrid snippetSkip={ true }>
               <ChartTableRows>
-                { data.map(({ label, data }, i) =>
+                { rowData.map(({ label, data }, i) =>
                   <ChartTableRow key={ label } snippetSkip={ i > 0 }>
                     <ChartTableLabel>{ label }</ChartTableLabel>
                     <ChartTableVisual>
@@ -45,8 +74,8 @@ export default class DotPlotExample extends Component {
                 ) }
               </ChartTableRows>
             </ChartTableGrid>
-            <ChartTableAxis title="% of each something" />
-            <ChartTableKey>
+            <ChartTableAxis  snippetSkip={ true } title="% of each something" />
+            <ChartTableKey snippetSkip={ true }>
               <ChartKey>
                 { labels.map(({ name, color }) =>
                   <ChartKeyItem key={ name } label={ name }>

--- a/src/charts/dot-plot/example/index.js
+++ b/src/charts/dot-plot/example/index.js
@@ -1,4 +1,5 @@
 module.exports = [
   require('./dot-plot').default,
   require('./dot-plot-table').default,
+  require('./dot-plot-table-collapsible').default,
 ];


### PR DESCRIPTION
Fixes:
* Removes lodash as **it's not a dependency**
* Sets height to `auto` when ChartTable is collapsable and is in the expanded state.
* Removes collapsable behaviour when no collapsable props are set. 
* Removes a workaround that was added to pass tests. 