### PR TITLE
docs(StaticSite): Fixes static site generation

### DIFF
--- a/style-guide/routes.js
+++ b/style-guide/routes.js
@@ -224,7 +224,7 @@ export default (
         <Route
             path="chart"
             name="Chart"
-            apiDocs={ ['Chart'] }
+            apiDocs={ ['Chart', 'ChartBody', 'ChartHeader', 'ChartTitle'] }
             examples={ require('../src/charts/chart/example') }
             component={ Doc } />
         <Route

--- a/webpack.static.config.js
+++ b/webpack.static.config.js
@@ -88,7 +88,6 @@ module.exports = {
         '/docs/composites/pagination',
         '/docs/composites/usermenu',
         '/docs/charts/bars',
-        '/docs/charts/bar-chart',
         '/docs/charts/chart',
         '/docs/charts/chart-heading',
         '/docs/charts/chart-table',


### PR DESCRIPTION
Looks like `'/docs/charts/bar-chart'` had been accidentally added back in... probably due to some dodgy conflict resolving 😏 