### PR TITLE
chore(Travis): Speed up travis builds and deploys by reducing babel p…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist
 lib
 static
+tmp
 node_modules
 npm-debug.log
 yarn-error.log

--- a/.jest.ci.json
+++ b/.jest.ci.json
@@ -1,6 +1,7 @@
 {
   "moduleNameMapper": {
     "^.+\\.css$": "<rootDir>/test/__mocks__/styleMock.js",
-    "^bw-axiom$": "<rootDir>/src/index.js"
-  }
+    "^bw-axiom$": "<rootDir>/tmp/index.js"
+  },
+  "transform": {}
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ cache:
   directories:
   - "~/bin"
   - "~/opt"
+before_install:
+- mkdir tmp
+before_script:
+- bash ./deploy/travis_setup.sh
 script:
 - yarn lint
-- yarn test
+- yarn ci:test
+- yarn ci:build:static
 after_success:
 - bash ./deploy/publish_to_npm.sh
 - bash ./deploy/deploy_to_ghpages.sh

--- a/deploy/deploy_to_gcp.sh
+++ b/deploy/deploy_to_gcp.sh
@@ -12,7 +12,7 @@ fi
 curl ci-utils.bwcom.io/gcloud/install | bash
 curl ci-utils.bwcom.io/gcloud/auth | bash
 
-yarn build-css
+yarn build:css
 
 gsutil \
   -h "Content-Encoding:gzip" \

--- a/deploy/travis_setup.sh
+++ b/deploy/travis_setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+rm -rf tmp
+mkdir tmp
+rsync -a --prune-empty-dirs --exclude 'example/*' src/* tmp
+NODE_ENV=production BABEL_ENV=production node_modules/.bin/babel tmp --out-dir tmp

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
     "node": ">=6.0.0"
   },
   "scripts": {
-    "build-css": "NODE_ENV=production BABEL_ENV=production webpack --config webpack.css.config.js",
-    "build-static": "NODE_ENV=production BABEL_ENV=production webpack --config webpack.static.config.js",
-    "gh-pages": "BASENAME_ENV=\"'/axiom/'\" yarn build-static && gh-pages -d ./static --repo git@github.com:BrandwatchLtd/axiom.git",
-    "lint": "yarn run lint-js && yarn run lint-css",
-    "lint-css": "stylelint 'src/**/*.css' 'style-guide/**/*.css'",
-    "lint-js": "eslint --config .eslintrc ./src ./style-guide",
-    "prepublish": "rm -rf ./lib && yarn prepublish-js && yarn prepublish-css",
-    "prepublish-css": "rsync -a --prune-empty-dirs --exclude 'example/*.css' --include '*/' --include '*.css' --include 'theme-*.json' --exclude '*' ./src/* ./lib",
-    "prepublish-js": "NODE_ENV=production BABEL_ENV=production babel ./src --ignore example,*.test.js --out-dir ./lib",
+    "build:css": "NODE_ENV=production BABEL_ENV=production webpack --config webpack.css.config.js",
+    "build:static": "NODE_ENV=production BABEL_ENV=production webpack --config webpack.static.config.js",
+    "ci:build:static": "BASENAME_ENV=\"'/axiom/'\" yarn build:static",
+    "ci:test": "NODE_ENV=production jest --testPathPattern tmp --config .jest.ci.json",
+    "gh-pages": "gh-pages -d ./static --repo git@github.com:BrandwatchLtd/axiom.git",
+    "lint": "yarn run lint:js && yarn run lint:css",
+    "lint:css": "stylelint 'src/**/*.css' 'style-guide/**/*.css'",
+    "lint:js": "eslint --config .eslintrc src style-guide",
+    "prepublish": "rm -rf lib && rsync -a --prune-empty-dirs --exclude '*.test.js' --exclude '__snapshots__/*' tmp/ lib",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "start": "webpack-dev-server --port 4000 --inline --hot --history-api-fallback --content-base style-guide/",
-    "test": "NODE_ENV=production BABEL_ENV=production jest --config .jest.json"
+    "test": "NODE_ENV=production BABEL_ENV=production jest --testPathPattern src --config .jest.json"
   },
   "dependencies": {
     "classnames": "^2.2.1",


### PR DESCRIPTION
…asses

Jest on Travis is super slow and sometimes times out. This is a test to see if running babel first separately speeds things up. It also uses the babel stuff for prepublishing. 

Also I've added `build:static` to the script section to highlight any issues with the state site generation in PRs. 

Local test runs. 

```
# Running Jest with Babel
[1] - 45.746s
[2] - 41.68s
[3] - 40.597s

# Running Jest on pre-babelified (times include babel run)
[1] - 25.3s
[2] - 27.88s
[3] - 27.516s
```