### PR TITLE
fix(Global CSS): Moves globally applied styles to a separate file 

### DIFF
--- a/src/components/base/Base.css
+++ b/src/components/base/Base.css
@@ -1,7 +1,7 @@
+@import './globals';
 @import '../../materials/colors';
 @import '../../materials/layout';
 @import '../../materials/sizing';
-@import '../../materials/typography';
 
 /* Hack: around webkits autofill styling */
 @keyframes inputAutofillFix {
@@ -34,55 +34,6 @@
 @keyframes spin {
   from { transform: rotate(0deg); }
   to   { transform: rotate(360deg); }
-}
-
-/* stylelint-disable selector-no-universal */
-*,
-*::before,
-*::after {
-  box-sizing: inherit;
-}
-/* stylelint-enable */
-
-html,
-body {
-  box-sizing: border-box;
-}
-
-html {
-  font-size: 100%;
-  /* stylelint-disable property-no-vendor-prefix */
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  /* stylelint-enable property-no-vendor-prefix */
-}
-
-body {
-  margin: 0;
-  font-family: var(--font-family-body);
-  font-size: var(--font-size-body);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-variant-ligatures: common-ligatures;
-  text-rendering: optimizeLegibility;
-  line-height: var(--line-height-body);
-}
-
-/* stylelint-disable selector-no-type */
-button {
-  /* normalise button styles */
-  margin: 0;
-  font: inherit;
-
-  /* Show the overflow in Edge. */
-  overflow: visible;
-}
-/* stylelint-enable selector-no-type */
-
-/* Remove the inner border and padding in Firefox. */
-button::-moz-focus-inner {
-  padding: 0;
-  border-style: none;
 }
 
 /* stylelint-disable declaration-no-important */

--- a/src/components/base/globals.css
+++ b/src/components/base/globals.css
@@ -1,0 +1,61 @@
+@import '../../materials/typography';
+
+/* stylelint-disable property-no-vendor-prefix, selector-no-type */
+/* stylelint-disable selector-no-universal */
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+/* stylelint-enable selector-no-universal */
+
+html,
+body {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 100%;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-body);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-variant-ligatures: common-ligatures;
+  text-rendering: optimizeLegibility;
+  line-height: var(--line-height-body);
+}
+
+button,
+hr,
+input {
+  overflow: visible; /*  Show the overflow in Edge. */
+}
+
+input,
+textarea {
+  margin: 0; /* Remove the margin in Firefox and Safari. */
+  font: inherit;
+}
+
+textarea {
+  overflow: auto; /* Remove the default vertical scrollbar in IE. */
+}
+
+/* normalise button styles */
+button {
+  margin: 0;
+  font: inherit;
+
+  /* Remove the inner border and padding in Firefox. */
+  &::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+  }
+}
+

--- a/src/components/form/TextArea.css
+++ b/src/components/form/TextArea.css
@@ -7,7 +7,6 @@
   border: var(--component-border-width) solid var(--cmp-input-border-color);
   border-radius: var(--component-border-radius);
   background-color: var(--cmp-input-background-color);
-  overflow: auto; /* Remove the default vertical scrollbar in IE. */
   resize: none;
   transition-property: border-color;
   transition-duration: var(--transition-time-base);

--- a/src/components/form/TextGroup.css
+++ b/src/components/form/TextGroup.css
@@ -5,9 +5,7 @@
 .ax-textarea {
   width: 100%;
   min-width: 0;
-  margin: 0; /* Remove the margin in Firefox and Safari. */
   color: inherit;
-  font: inherit;
   appearance: none;
 
   &::placeholder {

--- a/src/components/form/TextInput.css
+++ b/src/components/form/TextInput.css
@@ -24,7 +24,6 @@
   background-color: transparent;
   text-overflow: ellipsis;
   line-height: var(--component-line-height);
-  overflow: visible; /*  Show the overflow in Edge. */
 
   &::placeholder {
     color: var(--cmp-input-color-placeholder);

--- a/src/components/typography/HorizontalRule.css
+++ b/src/components/typography/HorizontalRule.css
@@ -6,5 +6,4 @@
   border-right: 0;
   border-bottom: 0;
   border-left: 0;
-  overflow: visible; /* Show the overflow in Edge. */
 }


### PR DESCRIPTION
This is to provide a way for those styles to be ignored through import overriding.

Partially linked to #176.