### PR TITLE
fix(Chart Table): Fixes z-index issue

### DIFF
--- a/src/charts/chart-table/ChartTable.css
+++ b/src/charts/chart-table/ChartTable.css
@@ -24,6 +24,7 @@
 }
 
 .ax-chart-table__rows-container {
+  position: relative;
   overflow-y: hidden;
   transition-property: height;
   transition-duration: var(--transition-time-base);
@@ -50,7 +51,6 @@
   right: var(--cmp-label-width);
   bottom: 0;
   flex-direction: column;
-  z-index: -1;
 }
 
 .ax-chart-table__grid-lines {

--- a/src/charts/chart-table/ChartTableGrid.js
+++ b/src/charts/chart-table/ChartTableGrid.js
@@ -23,8 +23,6 @@ export default class ChartTableGrid extends Component {
 
     return (
       <Base { ...rest } className="ax-chart-table__grid-container">
-        { children }
-
         <div
             className="ax-chart-table__grid"
             style={ { left: labelColumnWidth } }>
@@ -49,6 +47,7 @@ export default class ChartTableGrid extends Component {
             </svg>
           </div>
         </div>
+        { children }
       </Base>
     );
   }


### PR DESCRIPTION
The vertical lines in the chart had a z-index applied to stack them above the dots. This caused them not to be stacked behind the body when global position was used changing their z-index context. This PR moves the vertical lines above `ax-chart-table__grid` in the DOM. 