### PR TITLE
fix(ImageCircle): make src an optional requirement for ImageCircle

### DIFF
--- a/src/components/image/ImageCircle.js
+++ b/src/components/image/ImageCircle.js
@@ -11,7 +11,7 @@ export default class ImageCircle extends Component {
     overlayIconName: PropTypes.string,
     overlayIconSize: PropTypes.string,
     size: PropTypes.string.isRequired,
-    src: PropTypes.string.isRequired,
+    src: PropTypes.string,
     onError: PropTypes.func,
   };
 


### PR DESCRIPTION
Removes a propType error when using Candytars.