### PR TITLE
fix(ChartTable): Fix icon alignment in expand/collapse button - broke…

### DIFF
--- a/src/charts/chart-table/ChartTable.css
+++ b/src/charts/chart-table/ChartTable.css
@@ -95,7 +95,3 @@
   transform: translate(-50%, 0);
   text-align: center;
 }
-
-.ax-chart-table__collapse-expand-text {
-  margin-left: calc(var(--spacing-grid-size) * 2);
-}

--- a/src/charts/chart-table/ChartTableAxis.js
+++ b/src/charts/chart-table/ChartTableAxis.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import {
   Base,
+  Grid,
+  GridCell,
   Icon,
   Link,
   Paragraph,
@@ -62,21 +64,16 @@ export default class ChartTableAxis extends Component {
               style={ { flexBasis: labelColumnWidth } }>
             {collapsible && (
               <Link onClick={ toggleExpand } style="subtle">
-                {isExpanded ? (
-                  <Strong>
-                    <Icon name="box-collapse"/>
-                    <span className="ax-chart-table__collapse-expand-text">
-                      Collapse
-                    </span>
-                  </Strong>
-                ) : (
-                  <Strong>
-                    <Icon name="box-expand"/>
-                    <span className="ax-chart-table__collapse-expand-text">
-                      {`See All ${rowsCount} ${expandButtonSuffix}`}
-                    </span>
-                  </Strong>
-                )}
+                <Strong>
+                  <Grid gutters="tiny" responsive={ false } verticalAlign="middle">
+                    <GridCell shrink={ true }>
+                      <Icon name={ `box-${isExpanded ? 'collapse' : 'expand'}` }/>
+                    </GridCell>
+                    <GridCell shrink={ true }>
+                      {isExpanded ? 'Collapse' : `See All ${rowsCount} ${expandButtonSuffix}`}
+                    </GridCell>
+                  </Grid>
+                </Strong>
               </Link>
             )}
           </div>


### PR DESCRIPTION
…n in 85012607c20f8103809471d9a28c35e7fdf60a91

The icon display was changed to block which caused the icon and text to pop onto separate lines. This fixes that