### PR TITLE
feat(Position): Adds option to specify where position nodes are appended

### DIFF
--- a/src/components/position/Position.js
+++ b/src/components/position/Position.js
@@ -12,6 +12,7 @@ export default class Position extends Component {
     children: PropTypes.array.isRequired,
     isVisible: PropTypes.bool.isRequired,
     offset: PropTypes.oneOf(['start', 'middle', 'end']),
+    parentNode: PropTypes.object,
     position: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
     onMaskClick: PropTypes.func,
   };
@@ -67,9 +68,12 @@ export default class Position extends Component {
   }
 
   createReactRootNode() {
+    const parentNode = this.props.parentNode || document.body;
     this._reactRootNode = document.createElement('div');
     this._reactRootNode.classList.add('AxiomPositionRoot');
-    document.body.appendChild(this._reactRootNode);
+
+    parentNode.appendChild(this._reactRootNode);
+
     this.renderSubtree();
   }
 
@@ -103,9 +107,12 @@ export default class Position extends Component {
   }
 
   destroy() {
+    const parentNode = this.props.parentNode || document.body;
+
     this._popper.destroy();
     ReactDOM.unmountComponentAtNode(this._reactRootNode);
-    document.body.removeChild(this._reactRootNode);
+
+    parentNode.removeChild(this._reactRootNode);
 
     delete this._reactRootNode;
     delete this._content;


### PR DESCRIPTION
By default this will be document.body, but when Axiom is being used
within a wider application which uses a wrapper node, we need to ensure
the Position node remains within the wrapper.

Open to alternative approaches