### PR TITLE
feat(Scripts): Adds a build:link script for use with npm link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ cd axiom
 yarn install
 yarn start
 ```
+
+### Testing within an application
+
+Npm/yarn link won't work out of the box as the `main` directory specified in `package.json` is `lib`. To populate this directory with your local changes, run `yarn build:local`. You can then run `npm link` as normal, and then `npm link bw-axiom` from your application directory.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build:css": "NODE_ENV=production BABEL_ENV=production webpack --config webpack.css.config.js",
     "build:static": "NODE_ENV=production BABEL_ENV=production webpack --config webpack.static.config.js",
+    "build:local": ". ./deploy/travis_setup.sh && yarn prepublish",
     "ci:build:static": "BASENAME_ENV=\"'/axiom/'\" yarn build:static",
     "ci:test": "NODE_ENV=production jest --testPathPattern tmp --config .jest.ci.json",
     "gh-pages": "gh-pages -d ./static --repo git@github.com:BrandwatchLtd/axiom.git",


### PR DESCRIPTION
Just a suggestion, it's fine if a) there's a better way or b) it's not deemed useful enough. It just took me a little while & a little help to figure out.