### PR TITLE
fix(Bars): Safari collapsing horizontal bars

### DIFF
--- a/src/charts/bars/Bar.css
+++ b/src/charts/bars/Bar.css
@@ -4,7 +4,6 @@
 
 .ax-bars__bar {
   display: flex;
-  flex: 1 1 0%;
 }
 
 .ax-bars__bar--center {
@@ -112,6 +111,13 @@
 .ax-bars--left {
   & .ax-bars__bar-label {
     flex: 0 0 var(--cmp-label-width);
+  }
+}
+
+.ax-bars--up,
+.ax-bars--down {
+  & .ax-bars__bar {
+    flex: 1 1 0%;
   }
 }
 


### PR DESCRIPTION
Fixes an issue with the horizontal bars collapsing in Safari. 

| **Before**  | **After** |
|---|---|
|<img width="493" alt="screen shot 2017-06-06 at 14 06 10" src="https://cloud.githubusercontent.com/assets/7130591/26830650/713ee764-4ac1-11e7-918b-9bb5dcd5e58e.png">|<img width="495" alt="screen shot 2017-06-06 at 14 07 45" src="https://cloud.githubusercontent.com/assets/7130591/26830680/8de2228c-4ac1-11e7-8a77-766cbe9cb255.png">|