### PR TITLE
feat(DotPlotChart): Adds  prop to  to allow hiding of the axis

### DIFF
--- a/src/charts/dot-plot/DotPlotChart.js
+++ b/src/charts/dot-plot/DotPlotChart.js
@@ -51,6 +51,7 @@ export default class DotPlotChart extends Component {
     })).isRequired,
     expandButtonSuffix: PropTypes.string,
     labelColumnWidth: PropTypes.string.isRequired,
+    showAxis: PropTypes.bool,
     showKey: PropTypes.bool,
     xAxisLabels: PropTypes.arrayOf(PropTypes.string),
   };
@@ -64,6 +65,7 @@ export default class DotPlotChart extends Component {
   }
 
   static defaultProps = {
+    showAxis: true,
     showKey: true,
   };
 
@@ -91,6 +93,7 @@ export default class DotPlotChart extends Component {
       data,
       expandButtonSuffix,
       labelColumnWidth,
+      showAxis,
       showKey,
       xAxisLabels,
     } = this.props;
@@ -130,9 +133,9 @@ export default class DotPlotChart extends Component {
             ) }
           </ChartTableRows>
         </ChartTableGrid>
-        <ChartTableAxis
+        { showAxis && <ChartTableAxis
             labels={ xAxisLabels }
-            title={ axisTitle } />
+            title={ axisTitle } /> }
         <ChartTableKey>
           { showKey && <ChartKey>
             { chartKey.map(({ label, color }) =>

--- a/src/charts/dot-plot/example/index.js
+++ b/src/charts/dot-plot/example/index.js
@@ -3,5 +3,5 @@ module.exports = [
   require('./collapsible').default,
   require('./context').default,
   require('./custom-x-labels').default,
-  require('./no-key').default,
+  require('./no-key-or-axis').default,
 ];

--- a/src/charts/dot-plot/example/no-key-or-axis.js
+++ b/src/charts/dot-plot/example/no-key-or-axis.js
@@ -6,15 +6,15 @@ import { chartKey, data } from './data';
 export default class DotPlotChartExample extends Component {
   render() {
     return (
-      <Example name="DotPlotChart without chart key or labels">
+      <Example name="DotPlotChart without chart key or axis">
         <Snippet>
           <DotPlotChart
               axisTitle=""
               chartKey={ chartKey }
               data={ data }
               labelColumnWidth="11rem"
-              showKey={ false }
-              xAxisLabels={ [] } />
+              showAxis={ false }
+              showKey={ false } />
         </Snippet>
       </Example>
     );


### PR DESCRIPTION
Very similar to https://github.com/BrandwatchLtd/axiom/pull/232; I didn't spot that passing an empty array for the `xAxisLabels` property results in no gridlines. It was a bit of a hack anyway; this approach allows us to explicitly hide the axis.