### PR TITLE
Feat bar chart hover

### DIFF
--- a/src/charts/bar-chart/BarChart.js
+++ b/src/charts/bar-chart/BarChart.js
@@ -33,6 +33,16 @@ export default class BarChart extends Component {
     zoom: PropTypes.bool,
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      hoverColor: null,
+      hoverIndex: null,
+    };
+    this.onMouseEnter = (hoverIndex, hoverColor) => this.setState({ hoverColor, hoverIndex });
+    this.onMouseLeave = () => this.setState({ hoverColor: null, hoverIndex: null });
+  }
+
   render() {
     const {
       axisTitle,
@@ -71,8 +81,13 @@ export default class BarChart extends Component {
                         ContextComponent={ ContextComponent }
                         color={ color }
                         data={ data[index] }
+                        dataIndex={ index }
                         key={ color }
                         label={ label }
+                        labelStrong={ index === this.state.hoverIndex }
+                        onMouseEnter={ this.onMouseEnter }
+                        onMouseLeave={ this.onMouseLeave }
+                        showLabel={ color === this.state.hoverColor }
                         value={ value } />
                   ) }
                 </Bars>

--- a/src/charts/bar-chart/BarChartContext.js
+++ b/src/charts/bar-chart/BarChartContext.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import {
   Bar,
   Dropdown,
@@ -7,13 +7,18 @@ import {
   DropdownTarget,
 } from 'bw-axiom';
 
-export default class BarChartContext extends Component {
+export default class BarChartContext extends PureComponent {
   static propTypes = {
     ContextComponent: PropTypes.func,
     color: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
+    dataIndex: PropTypes.number.isRequired,
     label: PropTypes.string.isRequired,
+    labelStrong: PropTypes.bool.isRequired,
+    showLabel: PropTypes.bool.isRequired,
     value: PropTypes.number.isRequired,
+    onMouseEnter: PropTypes.func.isRequired,
+    onMouseLeave: PropTypes.func.isRequired,
   };
 
   render() {
@@ -21,18 +26,31 @@ export default class BarChartContext extends Component {
       ContextComponent,
       color,
       data,
+      dataIndex,
       label,
+      labelStrong,
+      onMouseEnter,
+      onMouseLeave,
+      showLabel,
       value,
       ...rest
     } = this.props;
+
+    const bar = (
+      <Bar { ...rest }
+          color={ color }
+          labelStrong={ labelStrong }
+          onMouseEnter={ () => onMouseEnter(dataIndex, color) }
+          onMouseLeave={ onMouseLeave }
+          percent={ value }
+          showLabel={ showLabel } />
+    );
 
     if (ContextComponent) {
       return (
         <Dropdown>
           <DropdownTarget>
-            <Bar { ...rest }
-                color={ color }
-                percent={ value } />
+            {bar}
           </DropdownTarget>
 
           <DropdownContent>
@@ -46,10 +64,6 @@ export default class BarChartContext extends Component {
       );
     }
 
-    return (
-      <Bar { ...rest }
-          color={ color }
-          percent={ value } />
-    );
+    return bar;
   }
 }

--- a/src/charts/bars/Bar.css
+++ b/src/charts/bars/Bar.css
@@ -1,5 +1,6 @@
 @import '../../materials/animations';
 @import '../../materials/colors';
+@import '../../materials/typography';
 @import '../vars';
 
 .ax-bars__bar {
@@ -12,7 +13,13 @@
 
 .ax-bars__bar-label {
   align-self: center;
+  opacity: 1;
   line-height: var(--cmp-chart-label-line-height);
+  transition: opacity var(--transition-time-base) var(--transition-function);
+}
+
+.ax-bars__bar-label--hidden {
+  opacity: 0;
 }
 
 .ax-bars__bar-rect {

--- a/src/charts/bars/Bar.js
+++ b/src/charts/bars/Bar.js
@@ -20,6 +20,7 @@ export default class Bar extends Component {
       'brown',
       'grey',
     ]).isRequired,
+    labelStrong: PropTypes.bool,
     minSize: PropTypes.string,
     percent: PropTypes.number.isRequired,
     showLabel: PropTypes.bool,
@@ -28,6 +29,7 @@ export default class Bar extends Component {
   };
 
   static defaultProps = {
+    labelStrong: false,
     minSize: '1rem',
   };
 
@@ -37,11 +39,15 @@ export default class Bar extends Component {
 
   render() {
     const { direction } = this.context;
-    const { color, onClick, minSize, percent, showLabel, size, ...rest } = this.props;
+    const { color, labelStrong, onClick, minSize, percent, showLabel, size, ...rest } = this.props;
     const isVertical = direction === 'up' || direction === 'down';
     const classes = classnames('ax-bars__bar', {
       'ax-bars__bar--center': size,
       'ax-bars__bar--clickable': onClick,
+    });
+
+    const labelClasses = classnames('ax-bars__bar-label', {
+      'ax-bars__bar-label--hidden': !showLabel,
     });
 
     const rectClasses = classnames('ax-bars__bar-rect',
@@ -65,12 +71,9 @@ export default class Bar extends Component {
           onClick={ onClick }
           style={ style }>
         <div className={ rectClasses } style={ rectStyle } />
-
-        { showLabel && (
-          <div className="ax-bars__bar-label">
-            <Small textColor="subtle">{ percent }%</Small>
-          </div>
-        ) }
+        <div className={ labelClasses }>
+          <Small textStrong={ labelStrong }>{ percent }%</Small>
+        </div>
       </Base>
     );
   }

--- a/src/charts/bars/Bar.test.js
+++ b/src/charts/bars/Bar.test.js
@@ -56,6 +56,12 @@ describe('Bar', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders with labelStrong', () => {
+    const component = getComponent({ labelStrong: true, showLabel: true });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   describe('renders with size', () => {
     ['up', 'down', 'left', 'right'].forEach((direction) => {
       it(direction, () => {

--- a/src/charts/bars/__snapshots__/Bar.test.js.snap
+++ b/src/charts/bars/__snapshots__/Bar.test.js.snap
@@ -31,6 +31,16 @@ exports[`Bar renders with color amber 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -68,6 +78,16 @@ exports[`Bar renders with color blue 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -105,6 +125,16 @@ exports[`Bar renders with color brown 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -142,6 +172,16 @@ exports[`Bar renders with color chartreuse 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -179,6 +219,16 @@ exports[`Bar renders with color green 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -216,6 +266,16 @@ exports[`Bar renders with color grey 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -253,6 +313,16 @@ exports[`Bar renders with color lilac 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -290,6 +360,16 @@ exports[`Bar renders with color orange 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -327,6 +407,16 @@ exports[`Bar renders with color pink 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -364,6 +454,16 @@ exports[`Bar renders with color purple 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -401,6 +501,16 @@ exports[`Bar renders with color rose 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -438,6 +548,16 @@ exports[`Bar renders with color teal 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -475,6 +595,63 @@ exports[`Bar renders with defaultProps 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Bar renders with labelStrong 1`] = `
+<div
+  className="ax-bars ax-bars--up"
+>
+  <div
+    className="ax-bars__bars-container"
+  >
+    <div
+      className="ax-bars__bars"
+    >
+      <div
+        className="ax-bars__bar"
+        onClick={undefined}
+        style={
+          Object {
+            "height": "50%",
+            "width": false,
+          }
+        }
+      >
+        <div
+          className="ax-bars__bar-rect ax-bars__bar-rect--rose"
+          style={
+            Object {
+              "height": false,
+              "minHeight": false,
+              "minWidth": "1rem",
+              "width": undefined,
+            }
+          }
+        />
+        <div
+          className="ax-bars__bar-label"
+        >
+          <small
+            className="ax-small ax-text--strong"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -512,6 +689,16 @@ exports[`Bar renders with minSize down 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -549,6 +736,16 @@ exports[`Bar renders with minSize left 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -586,6 +783,16 @@ exports[`Bar renders with minSize right 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -623,6 +830,16 @@ exports[`Bar renders with minSize up 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -660,6 +877,16 @@ exports[`Bar renders with onClick 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -701,7 +928,7 @@ exports[`Bar renders with showLabel 1`] = `
           className="ax-bars__bar-label"
         >
           <small
-            className="ax-small ax-text--color-subtle"
+            className="ax-small"
           >
             50
             %
@@ -744,6 +971,16 @@ exports[`Bar renders with size and minSize down 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -781,6 +1018,16 @@ exports[`Bar renders with size and minSize left 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -818,6 +1065,16 @@ exports[`Bar renders with size and minSize right 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -855,6 +1112,16 @@ exports[`Bar renders with size and minSize up 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -892,6 +1159,16 @@ exports[`Bar renders with size down 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -929,6 +1206,16 @@ exports[`Bar renders with size left 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -966,6 +1253,16 @@ exports[`Bar renders with size right 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -1003,6 +1300,16 @@ exports[`Bar renders with size up 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>

--- a/src/charts/bars/__snapshots__/Bars.test.js.snap
+++ b/src/charts/bars/__snapshots__/Bars.test.js.snap
@@ -31,6 +31,16 @@ exports[`Bars renders with defaultProps 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -68,6 +78,16 @@ exports[`Bars renders with direction down 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -105,6 +125,16 @@ exports[`Bars renders with direction left 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -142,6 +172,16 @@ exports[`Bars renders with direction right 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -179,6 +219,16 @@ exports[`Bars renders with direction up 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>
@@ -216,6 +266,16 @@ exports[`Bars renders with label 1`] = `
             }
           }
         />
+        <div
+          className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+          <small
+            className="ax-small"
+          >
+            50
+            %
+          </small>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
First Axiom use of `PureComponent` 🎉  In the Basic BarChart example it cuts the calls to `BarChartContext`'s render method from 63 to 21 every time the mouse enters or leaves the component. As the component isn't publicly exposed I can't think of any disadvantages to this approach.

![screen shot 2017-06-13 at 15 17 05](https://user-images.githubusercontent.com/8782055/27086878-6ad78c48-504b-11e7-8033-3efab4eda7c0.png)

