### PR TITLE
feat(Position): Allow parentNode to be configured using context via

### DIFF
--- a/src/components/position/Position.js
+++ b/src/components/position/Position.js
@@ -20,7 +20,11 @@ export default class Position extends Component {
   static defaultProps = {
     offset: 'middle',
     position: 'top',
-  }
+  };
+
+  static contextTypes = {
+    axiomPositionParentNode: PropTypes.object,
+  };
 
   constructor(props) {
     super(props);
@@ -68,7 +72,8 @@ export default class Position extends Component {
   }
 
   createReactRootNode() {
-    const parentNode = this.props.parentNode || document.body;
+    const parentNode = this.props.parentNode ||
+      this.context.axiomPositionParentNode || document.body;
     this._reactRootNode = document.createElement('div');
     this._reactRootNode.classList.add('AxiomPositionRoot');
 

--- a/src/components/position/example/context.js
+++ b/src/components/position/example/context.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Example, Snippet, Link } from 'style-guide';
+import { CodeSnippet, Example, Snippet, Link } from 'style-guide';
 import {
   Avatar,
   CheckBox,
@@ -138,6 +138,25 @@ export default class PositionExample extends Component {
             </GridCell>
           </Grid>
         </Snippet>
+
+        <Paragraph>
+          The parent node to which the positioned elements are inserted into can
+          be configured via context. This will apply to all uses of internally
+          Positioned elements, for example Dropdowns, ColorPickers and DataPickers.
+        </Paragraph>
+
+        <CodeSnippet language="js">{`
+static childContextTypes = {
+  axiomPositionParentNode: PropTypes.object,
+};
+
+getChildContext() {
+  return {
+    axiomPositionParentNode: document.body.querySelector('#custom-parent'),
+  };
+}
+`}
+        </CodeSnippet>
       </Example>
     );
   }


### PR DESCRIPTION
Position/Dropdown/Tooltip and other variants are used internally throughout Axiom. Requiring everyone to remember to pass the parentNode prop to Position internally and when used by the components is a lot of effort. 

Using context like below allows it be set once in the application using it. 

```js
  static childContextTypes = {
    axiomPositionParentNode: PropTypes.object,
  };

  getChildContext() {
    return {
      axiomPositionParentNode: document.body.querySelector('#custom-parent'),
    };
  }
```