### PR TITLE
fix(bullet-chart): fix bar height for small values

### DIFF
--- a/src/charts/bullet-chart/BulletBars.js
+++ b/src/charts/bullet-chart/BulletBars.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Base, Bar, Bars } from 'bw-axiom';
-import { arrayOfLength } from './utils';
+import { findBarGroupMax, arrayOfLength } from './utils';
 
 export default class BulletBars extends Component {
   static propTypes = {
@@ -19,6 +19,8 @@ export default class BulletBars extends Component {
       values,
       ...rest } = this.props;
 
+    const barGroupMax = values.reduce(findBarGroupMax);
+
     return (
       <Base { ...rest } className="ax-bullet-chart__block">
         <div className="ax-bullet-chart__bars">
@@ -30,7 +32,7 @@ export default class BulletBars extends Component {
                     key={ color }
                     label={ `${barLabel}%` }
                     percent={ value }
-                    showLabel={ showBarLabel }/>
+                    showLabel={ value === barGroupMax && showBarLabel }/>
               </Bars>
             </div>
                 )}

--- a/src/charts/bullet-chart/BulletBars.js
+++ b/src/charts/bullet-chart/BulletBars.js
@@ -1,12 +1,11 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Base, Bar, Bars } from 'bw-axiom';
-import { findBarGroupMax, arrayOfLength } from './utils';
+import { arrayOfLength } from './utils';
 
 export default class BulletBars extends Component {
   static propTypes = {
     barLabel: PropTypes.number,
-    dataSetMax: PropTypes.number.isRequired,
     label: PropTypes.string,
     showBarLabel: PropTypes.bool,
     values: arrayOfLength.bind(null, 2),
@@ -14,30 +13,15 @@ export default class BulletBars extends Component {
 
   render() {
     const {
-      dataSetMax,
       label,
       barLabel,
       showBarLabel,
       values,
       ...rest } = this.props;
 
-    const barGroupMax = values.reduce(findBarGroupMax);
-
-    const maxDataPoint = values[barGroupMax.index];
-    const minDataPoint = values[barGroupMax.index === 1 ? 0 : 1];
-
-    const barGroupHeight = (maxDataPoint.value / dataSetMax) * 100;
-
-    const style = {
-      height: `${barGroupHeight}%`,
-    };
-
-    maxDataPoint.value = 100;
-    minDataPoint.value = ((minDataPoint.value / barGroupMax.value) * 100);
-
     return (
       <Base { ...rest } className="ax-bullet-chart__block">
-        <div className="ax-bullet-chart__bars" style={ style }>
+        <div className="ax-bullet-chart__bars">
           { values.map(({ color, value }) =>
             <div className="ax-bullet-chart__bars-bar" key={ `${color}-div` }>
               <Bars direction="up" label={ label }>

--- a/src/charts/bullet-chart/BulletBars.test.js
+++ b/src/charts/bullet-chart/BulletBars.test.js
@@ -5,7 +5,6 @@ import { formattedData } from './BulletBars.test.fixture';
 
 function getComponent(props = {}) {
   props.values = formattedData;
-  props.dataSetMax = props.dataSetMax || 101;
 
   return renderer.create(
     <BulletBars { ...props }>
@@ -20,13 +19,13 @@ describe('BulletBars', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  describe('renders with the right height', () => {
-    [100, 300].forEach((dataSetMax) => {
-      it(dataSetMax, () => {
-        const component = getComponent({ dataSetMax });
-        const tree = component.toJSON();
-        expect(tree).toMatchSnapshot();
-      });
-    });
+  it('renders with the correct label', () => {
+    const props = {
+      barLabel: 'label for highest value',
+      showBarLabel: true,
+    };
+    const component = getComponent(props);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/src/charts/bullet-chart/BulletChart.css
+++ b/src/charts/bullet-chart/BulletChart.css
@@ -24,6 +24,7 @@
   flex-direction: column;
   align-items: center;
   width: 100%;
+  height: 100%;
 }
 
 .ax-bullet-chart__bars-bar:last-child {

--- a/src/charts/bullet-chart/BulletChart.js
+++ b/src/charts/bullet-chart/BulletChart.js
@@ -8,7 +8,7 @@ import ColumnChartRow from '../column-chart/ColumnChartRow';
 import ColumnChartXAxis from '../column-chart/ColumnChartXAxis';
 import ColumnChartXAxisLabel from '../column-chart/ColumnChartXAxisLabel';
 import './BulletChart.css';
-import { formatData, getHighestValue } from './utils';
+import { formatData } from './utils';
 
 export default class BulletChart extends Component {
   static propTypes = {
@@ -55,7 +55,6 @@ export default class BulletChart extends Component {
     } = this.props;
 
     const formattedData = formatData(chartKey, data);
-    const dataSetMax = getHighestValue(data);
 
     return (
       <Base { ...rest }
@@ -66,8 +65,7 @@ export default class BulletChart extends Component {
             { formattedData.map(({ values, label, subLabel }, index) =>
               <ColumnChartBars key={ index }>
                 <BulletBars
-                    barLabel={ values[labelIndex] && values[labelIndex].value }
-                    dataSetMax= { dataSetMax }
+                    barLabel={ values[labelIndex] && values[labelIndex].valueLabel }
                     label={ showSubLabel && subLabel }
                     showBarLabel={ showBarLabel }
                     values={ values }>

--- a/src/charts/bullet-chart/__snapshots__/BulletBars.test.js.snap
+++ b/src/charts/bullet-chart/__snapshots__/BulletBars.test.js.snap
@@ -6,11 +6,6 @@ exports[`BulletBars renders with defaultProps 1`] = `
 >
   <div
     className="ax-bullet-chart__bars"
-    style={
-      Object {
-        "height": "49.504950495049506%",
-      }
-    }
   >
     <div
       className="ax-bullet-chart__bars-bar"
@@ -29,7 +24,7 @@ exports[`BulletBars renders with defaultProps 1`] = `
               onClick={undefined}
               style={
                 Object {
-                  "height": "20%",
+                  "height": "10%",
                   "width": false,
                 }
               }
@@ -76,7 +71,7 @@ exports[`BulletBars renders with defaultProps 1`] = `
               onClick={undefined}
               style={
                 Object {
-                  "height": "100%",
+                  "height": "50%",
                   "width": false,
                 }
               }
@@ -110,17 +105,12 @@ exports[`BulletBars renders with defaultProps 1`] = `
 </div>
 `;
 
-exports[`BulletBars renders with the right height 100 1`] = `
+exports[`BulletBars renders with the correct label 1`] = `
 <div
   className="ax-bullet-chart__block"
 >
   <div
     className="ax-bullet-chart__bars"
-    style={
-      Object {
-        "height": "100%",
-      }
-    }
   >
     <div
       className="ax-bullet-chart__bars-bar"
@@ -139,7 +129,7 @@ exports[`BulletBars renders with the right height 100 1`] = `
               onClick={undefined}
               style={
                 Object {
-                  "height": "20%",
+                  "height": "10%",
                   "width": false,
                 }
               }
@@ -156,12 +146,12 @@ exports[`BulletBars renders with the right height 100 1`] = `
                 }
               />
               <div
-                className="ax-bars__bar-label ax-bars__bar-label--hidden"
+                className="ax-bars__bar-label"
               >
                 <small
                   className="ax-small"
                 >
-                  undefined%
+                  label for highest value%
                 </small>
               </div>
             </div>
@@ -186,7 +176,7 @@ exports[`BulletBars renders with the right height 100 1`] = `
               onClick={undefined}
               style={
                 Object {
-                  "height": "100%",
+                  "height": "50%",
                   "width": false,
                 }
               }
@@ -203,122 +193,12 @@ exports[`BulletBars renders with the right height 100 1`] = `
                 }
               />
               <div
-                className="ax-bars__bar-label ax-bars__bar-label--hidden"
+                className="ax-bars__bar-label"
               >
                 <small
                   className="ax-small"
                 >
-                  undefined%
-                </small>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`BulletBars renders with the right height 300 1`] = `
-<div
-  className="ax-bullet-chart__block"
->
-  <div
-    className="ax-bullet-chart__bars"
-    style={
-      Object {
-        "height": "33.33333333333333%",
-      }
-    }
-  >
-    <div
-      className="ax-bullet-chart__bars-bar"
-    >
-      <div
-        className="ax-bars ax-bars--up"
-      >
-        <div
-          className="ax-bars__bars-container"
-        >
-          <div
-            className="ax-bars__bars"
-          >
-            <div
-              className="ax-bars__bar"
-              onClick={undefined}
-              style={
-                Object {
-                  "height": "20%",
-                  "width": false,
-                }
-              }
-            >
-              <div
-                className="ax-bars__bar-rect ax-bars__bar-rect--blue"
-                style={
-                  Object {
-                    "height": false,
-                    "minHeight": false,
-                    "minWidth": "1rem",
-                    "width": undefined,
-                  }
-                }
-              />
-              <div
-                className="ax-bars__bar-label ax-bars__bar-label--hidden"
-              >
-                <small
-                  className="ax-small"
-                >
-                  undefined%
-                </small>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="ax-bullet-chart__bars-bar"
-    >
-      <div
-        className="ax-bars ax-bars--up"
-      >
-        <div
-          className="ax-bars__bars-container"
-        >
-          <div
-            className="ax-bars__bars"
-          >
-            <div
-              className="ax-bars__bar"
-              onClick={undefined}
-              style={
-                Object {
-                  "height": "100%",
-                  "width": false,
-                }
-              }
-            >
-              <div
-                className="ax-bars__bar-rect ax-bars__bar-rect--pink"
-                style={
-                  Object {
-                    "height": false,
-                    "minHeight": false,
-                    "minWidth": "1rem",
-                    "width": undefined,
-                  }
-                }
-              />
-              <div
-                className="ax-bars__bar-label ax-bars__bar-label--hidden"
-              >
-                <small
-                  className="ax-small"
-                >
-                  undefined%
+                  label for highest value%
                 </small>
               </div>
             </div>

--- a/src/charts/bullet-chart/__snapshots__/BulletBars.test.js.snap
+++ b/src/charts/bullet-chart/__snapshots__/BulletBars.test.js.snap
@@ -146,7 +146,7 @@ exports[`BulletBars renders with the correct label 1`] = `
                 }
               />
               <div
-                className="ax-bars__bar-label"
+                className="ax-bars__bar-label ax-bars__bar-label--hidden"
               >
                 <small
                   className="ax-small"

--- a/src/charts/bullet-chart/example/data.js
+++ b/src/charts/bullet-chart/example/data.js
@@ -5,9 +5,8 @@ export const chartKey =
   ];
 
 export const data = [
-  { label: 'Family', subLabel:'500%', values: { blue: 10, pink: 50 } },
-  { label: 'Games', subLabel:'105%', values: { blue: 40, pink: 90 } },
-  { label: 'Family & Parenting', subLabel:'0%', values: { blue: 50, pink: 50 } },
-  { label: 'Technology', subLabel:'300%', values: { blue: 25, pink: 75 } },
-  { label: 'Books', subLabel:'100%', values: { blue: 25, pink: 50 } },
+  { label: 'Family', subLabel:'-100%', values: { blue: 40, pink: 20 } },
+  { label: 'Games', subLabel:'-100%', values: { blue: 20, pink: 10 } },
+  { label: 'Phones', subLabel:'-100%', values: { blue: 5, pink: 2.5 } },
+  { label: 'Toys', subLabel:'100%', values: { blue: 20, pink: 40 } },
 ];

--- a/src/charts/bullet-chart/utils.js
+++ b/src/charts/bullet-chart/utils.js
@@ -1,11 +1,16 @@
 export function formatData(key, data) {
   const order = key.map(({ color }) => color);
+  const highestValue = getHighestValue(data);
 
   return data.map(({ label, subLabel, values }) => ({
     label,
     subLabel,
     values: Object.keys(values)
-      .map((color) => ({ color, value: values[color] }))
+      .map((color) => ({
+        color,
+        valueLabel: values[color],
+        value: Math.floor((values[color] / highestValue) * 100),
+      }))
       .sort((a, b) => order.indexOf(a.color) - order.indexOf(b.color)),
   }));
 }
@@ -24,11 +29,11 @@ export function getHighestValue(data) {
   return max;
 }
 
-export function findBarGroupMax ( acc, cur, index ) {
+export function findBarGroupMax ( acc, cur ) {
   if (cur.value > acc.value) {
-    return { value: cur.value, index: index };
+    return cur.value;
   } else {
-    return { value: acc.value, index: index - 1 };
+    return acc.value;
   }
 }
 


### PR DESCRIPTION
Fixes two issues with the bullet chart component.

1. Labels for both bars were showing this is now corrected to only show the label for the highest value in each group.
2. For smaller values the containing element was not large enough to hold the bars and labels. This has been fixed by setting a normalised height on each bar rather than the container. 

![screen shot 2017-06-26 at 16 18 34](https://user-images.githubusercontent.com/3940567/27546604-28530092-5a8b-11e7-93c3-b718b37771c9.png)
