### PR TITLE
fix(BarChartBars): label prop should be of type node not string

### DIFF
--- a/src/charts/bar-chart/BarChartBars.js
+++ b/src/charts/bar-chart/BarChartBars.js
@@ -10,7 +10,7 @@ export default class BarChartBars extends Component {
     benchmark: PropTypes.number,
     data: PropTypes.object.isRequired,
     hoverColor: PropTypes.string,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
     labelStrong: PropTypes.bool.isRequired,
     showBarLabel: PropTypes.bool,
     size: PropTypes.string,


### PR DESCRIPTION
I didn't really know how to test this with the new editable example - but this is what it should be!