### PR TITLE
fix(DotPlot): Benchmark line is now correct height

### DIFF
--- a/src/charts/dot-plot/DotPlot.css
+++ b/src/charts/dot-plot/DotPlot.css
@@ -45,6 +45,10 @@
   pointer-events: none;
 }
 
+.ax-dot-plot__benchmark-line {
+  height: var(--cmp-benchmark-line-height);
+}
+
 .ax-dot-plot__benchmark-line,
 .ax-dot-plot__difference-line {
   position: relative;
@@ -55,7 +59,8 @@
 
 .ax-dot-plot__benchmark-line-path {
   position: absolute;
-  height: var(--cmp-benchmark-line-height);
+  top: 0;
+  bottom: 0;
   border-right: var(--cmp-benchmark-line-width) solid var(--cmp-benchmark-line-color);
 }
 

--- a/src/charts/dot-plot/DotPlotBenchmarkLine.js
+++ b/src/charts/dot-plot/DotPlotBenchmarkLine.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 export default class DotPlotBenchmarkLine extends Component {
   static propTypes = {
     faded: PropTypes.bool,
+    height: PropTypes.string,
     value: PropTypes.number,
     width: PropTypes.string,
   };
@@ -15,8 +16,8 @@ export default class DotPlotBenchmarkLine extends Component {
   };
 
   render() {
-    const { faded, value, width, ...rest } = this.props;
-    const style = { width };
+    const { faded, height, value, width, ...rest } = this.props;
+    const style = { height, width };
     const lineStyle = { left: `${value}%` };
     const classes = classnames('ax-dot-plot__benchmark-line', {
       'ax-dot-plot__benchmark-line--faded': faded,

--- a/src/charts/dot-plot/DotPlotChart.js
+++ b/src/charts/dot-plot/DotPlotChart.js
@@ -158,7 +158,7 @@ export default class DotPlotChart extends Component {
             <ChartKey>
               { chartKeyBenchmarkLabel && (
                 <ChartKeyItem label={ chartKeyBenchmarkLabel }>
-                  <DotPlotBenchmarkLine width="0.75rem" />
+                  <DotPlotBenchmarkLine height="1rem" width="0.75rem" />
                 </ChartKeyItem>
               ) }
 


### PR DESCRIPTION
Was this:
![screen shot 2017-07-04 at 14 35 37](https://user-images.githubusercontent.com/8782055/27832277-167126b0-60c6-11e7-843b-6349dfbbfd1e.png)

Now this:
![screen shot 2017-07-04 at 14 35 17](https://user-images.githubusercontent.com/8782055/27832282-1b6ec4a6-60c6-11e7-82fa-902891d0ef5b.png)

🎉 