### PR TITLE
fix(ChartTableLabel): Use lighter shade for color

### DIFF
--- a/src/charts/chart-table/ChartTable.css
+++ b/src/charts/chart-table/ChartTable.css
@@ -74,6 +74,7 @@
   flex: 0 0 auto;
   padding-right: calc(var(--spacing-grid-size) * 2);
   padding-left: calc(var(--spacing-grid-size) * 6);
+  color: var(--color-context-text-subtle);
 }
 
 .ax-chart-table__visual {


### PR DESCRIPTION
before:
![screen shot 2017-07-04 at 14 51 47](https://user-images.githubusercontent.com/8782055/27832892-593ef1c8-60c8-11e7-884c-28b53f876280.png)

after:
![screen shot 2017-07-04 at 14 51 33](https://user-images.githubusercontent.com/8782055/27832889-564c0b36-60c8-11e7-96bb-b7f2b031bfb7.png)


🦄 