### PR TITLE
chore(GCP): Enable multi-threaded on acl changes

### DIFF
--- a/deploy/deploy_to_gcp.sh
+++ b/deploy/deploy_to_gcp.sh
@@ -20,4 +20,4 @@ gsutil \
   cp -r dist/*.css gs://$STORAGE_BUCKET
 
 # Set public access to bucket
-gsutil acl -r ch -u AllUsers:R gs://$STORAGE_BUCKET
+gsutil -m acl -r ch -u AllUsers:R gs://$STORAGE_BUCKET


### PR DESCRIPTION
Enable multi-threaded updates as suggested by this warning. 

> NOTE: You are performing a sequence of gsutil operations that may
run significantly faster if you instead use gsutil -m acl ... Please
see the -m section under "gsutil help options" for further information
about when gsutil -m can be advantageous.