### PR TITLE
fix(ChedioButtox): Pass onClick handler to Base component so event bubbling is handled correctly

### DIFF
--- a/src/components/context/__snapshots__/ContextMenuItem.test.js.snap
+++ b/src/components/context/__snapshots__/ContextMenuItem.test.js.snap
@@ -46,6 +46,7 @@ exports[`ContextMenuItem renders with multiSelect 1`] = `
   >
     <label
       className="ax-chedio-buttox__container ax-space--x2"
+      onClick={undefined}
     >
       <input
         checked={undefined}
@@ -77,6 +78,7 @@ exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
   >
     <label
       className="ax-chedio-buttox__container ax-space--x2"
+      onClick={undefined}
     >
       <input
         checked={true}

--- a/src/components/form/ChedioButtox.js
+++ b/src/components/form/ChedioButtox.js
@@ -11,6 +11,7 @@ export default class ChedioButtox extends Component {
     indicatorClassName: PropTypes.string.isRequired,
     inputClassName: PropTypes.string.isRequired,
     inputType: PropTypes.oneOf(['checkbox', 'radio']).isRequired,
+    onClick: PropTypes.func,
   };
 
   render() {
@@ -20,6 +21,7 @@ export default class ChedioButtox extends Component {
       inputClassName,
       inputType,
       indicatorClassName,
+      onClick,
       ...rest
     } = this.props;
 
@@ -28,7 +30,7 @@ export default class ChedioButtox extends Component {
     });
 
     return (
-      <Base Component="label" className={ classes } space="x2">
+      <Base Component="label" className={ classes } onClick={ onClick } space="x2">
         <input { ...rest }
             className={ classnames('ax-chedio-buttox', inputClassName) }
             disabled={ disabled }

--- a/src/components/form/__snapshots__/CheckBox.test.js.snap
+++ b/src/components/form/__snapshots__/CheckBox.test.js.snap
@@ -3,6 +3,7 @@
 exports[`CheckBox renders with defaultProps 1`] = `
 <label
   className="ax-chedio-buttox__container ax-space--x2"
+  onClick={undefined}
 >
   <input
     className="ax-chedio-buttox ax-checkbox"

--- a/src/components/form/__snapshots__/CheckBoxGroup.test.js.snap
+++ b/src/components/form/__snapshots__/CheckBoxGroup.test.js.snap
@@ -6,6 +6,7 @@ exports[`CheckBox renders with defaultProps 1`] = `
 >
   <label
     className="ax-chedio-buttox__container ax-space--x2"
+    onClick={undefined}
   >
     <input
       className="ax-chedio-buttox ax-checkbox"

--- a/src/components/form/__snapshots__/ChedioButtox.test.js.snap
+++ b/src/components/form/__snapshots__/ChedioButtox.test.js.snap
@@ -3,6 +3,7 @@
 exports[`ChedioButtox renders when disabled 1`] = `
 <label
   className="ax-chedio-buttox__container ax-chedio-buttox__container--disabled ax-space--x2"
+  onClick={undefined}
 >
   <input
     className="ax-chedio-buttox ax-ipsum"
@@ -23,6 +24,7 @@ exports[`ChedioButtox renders when disabled 1`] = `
 exports[`ChedioButtox renders with defaultProps 1`] = `
 <label
   className="ax-chedio-buttox__container ax-space--x2"
+  onClick={undefined}
 >
   <input
     className="ax-chedio-buttox ax-ipsum"

--- a/src/components/form/__snapshots__/ChedioButtoxGroup.test.js.snap
+++ b/src/components/form/__snapshots__/ChedioButtoxGroup.test.js.snap
@@ -6,6 +6,7 @@ exports[`ChedioButtoxGroup renders with defaultProps 1`] = `
 >
   <label
     className="ax-chedio-buttox__container ax-space--x2"
+    onClick={undefined}
   >
     <input
       className="ax-chedio-buttox"
@@ -23,6 +24,7 @@ exports[`ChedioButtoxGroup renders with defaultProps 1`] = `
   </label>
   <label
     className="ax-chedio-buttox__container ax-space--x2"
+    onClick={undefined}
   >
     <input
       className="ax-chedio-buttox"

--- a/src/components/form/__snapshots__/RadioButton.test.js.snap
+++ b/src/components/form/__snapshots__/RadioButton.test.js.snap
@@ -3,6 +3,7 @@
 exports[`RadioButton renders with defaultProps 1`] = `
 <label
   className="ax-chedio-buttox__container ax-space--x2"
+  onClick={undefined}
 >
   <input
     className="ax-chedio-buttox ax-radio"

--- a/src/components/form/__snapshots__/RadioButtonGroup.test.js.snap
+++ b/src/components/form/__snapshots__/RadioButtonGroup.test.js.snap
@@ -6,6 +6,7 @@ exports[`RadioButton renders with defaultProps 1`] = `
 >
   <label
     className="ax-chedio-buttox__container ax-space--x2"
+    onClick={undefined}
   >
     <input
       className="ax-chedio-buttox ax-radio"


### PR DESCRIPTION
The issue is that when a user clicks the component the event target is the `span` element, but the handler is on the sibling `input` element. This means the event bubbles up to the component's parents before the input handler is fired which makes it impossible to stop propagation. Does anyone have any better ideas about how to fix this?

This solution is a bit of a hack because I've just moved the `onClick` handler.