### PR TITLE
chore(GCP): Corrected CSS file name

### DIFF
--- a/webpack.css.config.js
+++ b/webpack.css.config.js
@@ -34,7 +34,7 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(['dist']),
     new ExtractTextPlugin({
-      filename: `./dist/axiom-${version}.min.css`,
+      filename: `./dist/axiom.${version}.min.css`,
     }),
     new CompressionPlugin({
       asset: '[path]',


### PR DESCRIPTION
Fixes the CSS filename which changed in V25 due to the removal of separate theme builds. 