### PR TITLE
fix(Base): Sticky behaviour to support safari css prefixing

### DIFF
--- a/src/components/base/Base.css
+++ b/src/components/base/Base.css
@@ -70,6 +70,7 @@
     display: none !important;
   }
 }
+
 /* stylelint-enable */
 .ax-space--x0 {
   margin-top: 0;
@@ -121,4 +122,8 @@
 .ax-space--x8 {
   &:first-child { margin-top: 0; }
   &:last-child  { margin-bottom: 0; }
+}
+
+.ax-sticky {
+  position: sticky;
 }

--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -130,6 +130,7 @@ export default class Base extends Component {
       [`ax-hidden-until--${hiddenUntil}`]: hiddenUntil,
       [`ax-visible-until--${visibleUntil}`]: visibleUntil,
       [`ax-space--${space}`]: space,
+      'ax-sticky': sticky,
       [`ax-text--case-${textCase}`]: textCase,
       'ax-text--align-center': textCenter === true,
       [`ax-text--align-center--${textCenter}`]: textCenter && textCenter !== true,
@@ -151,7 +152,6 @@ export default class Base extends Component {
     if (sticky) {
       rest.style = {
         ...rest.style,
-        position: 'sticky',
         top: sticky,
       };
     }

--- a/src/components/base/__snapshots__/Base.test.js.snap
+++ b/src/components/base/__snapshots__/Base.test.js.snap
@@ -12,11 +12,10 @@ exports[`Base renders functional Component 1`] = `<span />`;
 
 exports[`Base renders sticky with style 1`] = `
 <div
-  className=""
+  className="ax-sticky"
   style={
     Object {
       "height": "1rem",
-      "position": "sticky",
       "top": "1rem",
     }
   }
@@ -25,10 +24,9 @@ exports[`Base renders sticky with style 1`] = `
 
 exports[`Base renders sticky without style 1`] = `
 <div
-  className=""
+  className="ax-sticky"
   style={
     Object {
-      "position": "sticky",
       "top": "1rem",
     }
   }


### PR DESCRIPTION
Safari currently only supports `position: sticky` with a `-webkit` prefix. So the position styling needs to be in the CSS for the autoprefixing to work. 