### PR TITLE
feat(ChartTable): Added configurable spacing between ChartTableRows

### DIFF
--- a/src/charts/bar-chart/BarChart.css
+++ b/src/charts/bar-chart/BarChart.css
@@ -1,11 +1,10 @@
-:root {
-  --cmp-benchmark-hang-over: calc(var(--spacing-grid-size) * 2);
-}
-
 .ax-bar-chart__bars {
   position: relative;
-  padding: var(--cmp-benchmark-hang-over) 0;
 }
+
+.ax-bar-chart__bars--x1 { padding: var(--spacing-grid-size--x1) 0; }
+.ax-bar-chart__bars--x2 { padding: var(--spacing-grid-size--x2) 0; }
+.ax-bar-chart__bars--x3 { padding: var(--spacing-grid-size--x3) 0; }
 
 .ax-bar-chart__benchmark-line-container {
   position: absolute;

--- a/src/charts/bar-chart/BarChart.js
+++ b/src/charts/bar-chart/BarChart.js
@@ -48,6 +48,8 @@ export default class BarChart extends Component {
     expandButtonSuffix: PropTypes.string,
     /** The width of the yAxis labels columns */
     labelColumnWidth: PropTypes.string.isRequired,
+    /** Spacing applied between Bar groups */
+    rowSpace: PropTypes.oneOf(['x1', 'x2', 'x3']),
     /** Option to always show the label next to bars, as opposed to on mouse over  */
     showBarLabel: PropTypes.bool,
     /** Control for toggling visibility of the key */
@@ -76,6 +78,7 @@ export default class BarChart extends Component {
   }
 
   static defaultProps = {
+    rowSpace: 'x2',
     showKey: true,
     zoomMax: 50,
   };
@@ -90,6 +93,7 @@ export default class BarChart extends Component {
       data,
       expandButtonSuffix,
       labelColumnWidth,
+      rowSpace,
       showBarLabel,
       showKey,
       size,
@@ -112,6 +116,7 @@ export default class BarChart extends Component {
             collapsedVisibleRowCount={ collapsedVisibleRowCount }
             expandButtonSuffix={ expandButtonSuffix }
             labelColumnWidth={ labelColumnWidth }
+            space={ rowSpace }
             xAxisLabels={ xAxisLabels }
             zoomTo={ zoomValue }>
           { formattedData.map(({ values, label, benchmark }, index) =>
@@ -125,6 +130,7 @@ export default class BarChart extends Component {
                 <BarChartBars
                     ContextComponent={ ContextComponent }
                     benchmark={ benchmark }
+                    benchmarkHeight={ rowSpace }
                     data={ data[index] }
                     fadeBenchmarkLine={ hoverIndex !== null }
                     hideBars={ hoverIndex !== null && hoverIndex !== index }

--- a/src/charts/bar-chart/BarChartBars.js
+++ b/src/charts/bar-chart/BarChartBars.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import { Bars } from 'bw-axiom';
 import BarChartContext from './BarChartContext';
 import BarChartBenchmarkLine from './BarChartBenchmarkLine';
@@ -8,6 +9,7 @@ export default class BarChartBars extends Component {
   static propTypes = {
     ContextComponent: PropTypes.func,
     benchmark: PropTypes.number,
+    benchmarkHeight: PropTypes.oneOf(['x1', 'x2', 'x3']),
     data: PropTypes.object.isRequired,
     fadeBenchmarkLine: PropTypes.bool.isRequired,
     hideBars: PropTypes.bool.isRequired,
@@ -25,6 +27,7 @@ export default class BarChartBars extends Component {
     const {
       ContextComponent,
       benchmark,
+      benchmarkHeight,
       data,
       fadeBenchmarkLine,
       hideBars,
@@ -38,8 +41,12 @@ export default class BarChartBars extends Component {
       onMouseLeave,
     } = this.props;
 
+    const classes = classnames('ax-bar-chart__bars', {
+      [`ax-bar-chart__bars--${benchmarkHeight}`]: benchmarkHeight,
+    });
+
     return (
-      <div className="ax-bar-chart__bars">
+      <div className={ classes }>
         <Bars direction="right">
           { values.map(({ color, value }) => {
             const isFaded = hoverColor && color !== hoverColor;

--- a/src/charts/chart-table/ChartTable.css
+++ b/src/charts/chart-table/ChartTable.css
@@ -1,7 +1,6 @@
 @import '../../materials/breakpoints';
 
 :root {
-  --cmp-chart-table-row-padding: calc((var(--spacing-grid-size) * 3) / 2);
   --cmp-chart-grid-line-width: 0.0625rem;
 }
 
@@ -26,8 +25,6 @@
   display: flex;
   align-items: center;
   margin-right: calc(var(--cmp-chart-overflow-space) * -1);
-  padding-top: var(--cmp-chart-table-row-padding);
-  padding-bottom: var(--cmp-chart-table-row-padding);
   border-radius: var(--component-border-radius);
   transition-property: background-color;
   transition-duration: var(--transition-time-base);
@@ -43,6 +40,27 @@
   transition-property: width;
   transition-duration: var(--transition-time-slow);
   transition-timing-function: var(--transition-function);
+}
+
+.ax-chart-table__rows-container--space-x1 {
+  & .ax-chart-table__grid-container,
+  & .ax-chart-table__row {
+    padding: var(--spacing-grid-size--x1) 0;
+  }
+}
+
+.ax-chart-table__rows-container--space-x2 {
+  & .ax-chart-table__grid-container,
+  & .ax-chart-table__row {
+    padding: calc(var(--spacing-grid-size--x3) / 2) 0;
+  }
+}
+
+.ax-chart-table__rows-container--space-x3 {
+  & .ax-chart-table__grid-container,
+  & .ax-chart-table__row {
+    padding: var(--spacing-grid-size--x3) 0;
+  }
 }
 
 .ax-chart-table__grid {

--- a/src/charts/chart-table/ChartTableRows.js
+++ b/src/charts/chart-table/ChartTableRows.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component, Children } from 'react';
+import classnames from 'classnames';
 import { Grid, GridCell, Icon, Link, Reveal, Small, Strong } from 'bw-axiom';
 
 export default class ChartTableRows extends Component {
@@ -8,12 +9,14 @@ export default class ChartTableRows extends Component {
     collapsedVisibleRowCount: PropTypes.number,
     expandButtonSuffix: PropTypes.string,
     labelColumnWidth: PropTypes.string.isRequired,
+    space: PropTypes.oneOf(['x1', 'x2', 'x3']),
     xAxisLabels: PropTypes.arrayOf(PropTypes.string),
     zoomTo: PropTypes.number,
   };
 
   static defaultProps = {
     expandButtonSuffix: 'Items',
+    space: 'x2',
     xAxisLabels: [ '0%', '10%', '20%', '30%', '40%', '50%', '60%', '70%', '80%', '90%', '100%'],
     zoomTo: 100,
   };
@@ -36,6 +39,7 @@ export default class ChartTableRows extends Component {
       collapsedVisibleRowCount,
       expandButtonSuffix,
       labelColumnWidth,
+      space,
       xAxisLabels,
       zoomTo,
       ...rest
@@ -49,8 +53,12 @@ export default class ChartTableRows extends Component {
       ((100% - ${labelColumnWidth}) / 100) * (${100 * (100 / zoomTo)})
     )`;
 
+    const classes = classnames(
+      'ax-chart-table__rows-container',
+      `ax-chart-table__rows-container--space-${space}`);
+
     return (
-      <div { ...rest } className="ax-chart-table__rows-container">
+      <div { ...rest } className={ classes }>
         <div className="ax-chart-table__grid-container" style={ { width: zoomWidth } }>
           <div className="ax-chart-table__grid" style={ { left: labelColumnWidth } }>
             { xAxisLabels.map((label, index) =>

--- a/src/charts/chart-table/__snapshots__/ChartTableRows.test.js.snap
+++ b/src/charts/chart-table/__snapshots__/ChartTableRows.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ChartTableRows renders with collapsedVisibleRowCount more than children count 1`] = `
 <div
-  className="ax-chart-table__rows-container"
+  className="ax-chart-table__rows-container ax-chart-table__rows-container--space-x2"
 >
   <div
     className="ax-chart-table__grid-container"
@@ -302,7 +302,7 @@ exports[`ChartTableRows renders with collapsedVisibleRowCount more than children
 
 exports[`ChartTableRows renders with defaultProps 1`] = `
 <div
-  className="ax-chart-table__rows-container"
+  className="ax-chart-table__rows-container ax-chart-table__rows-container--space-x2"
 >
   <div
     className="ax-chart-table__grid-container"
@@ -602,7 +602,7 @@ exports[`ChartTableRows renders with defaultProps 1`] = `
 
 exports[`ChartTableRows renders with expandButtonSuffix 1`] = `
 <div
-  className="ax-chart-table__rows-container"
+  className="ax-chart-table__rows-container ax-chart-table__rows-container--space-x2"
 >
   <div
     className="ax-chart-table__grid-container"
@@ -902,7 +902,7 @@ exports[`ChartTableRows renders with expandButtonSuffix 1`] = `
 
 exports[`ChartTableRows renders with xAxisLabels 1`] = `
 <div
-  className="ax-chart-table__rows-container"
+  className="ax-chart-table__rows-container ax-chart-table__rows-container--space-x2"
 >
   <div
     className="ax-chart-table__grid-container"

--- a/src/charts/chart/example/index.js
+++ b/src/charts/chart/example/index.js
@@ -37,7 +37,6 @@ class ChartExample extends Component {
         minimumHeight: '15rem',
       },
       ChartBody: {
-        horizontalAlign: 'middle',
         verticalAlign: 'middle',
       },
     };

--- a/src/charts/dot-plot/DotPlotChart.js
+++ b/src/charts/dot-plot/DotPlotChart.js
@@ -121,6 +121,7 @@ export default class DotPlotChart extends Component {
             collapsedVisibleRowCount={ collapsedVisibleRowCount }
             expandButtonSuffix={ expandButtonSuffix }
             labelColumnWidth={ labelColumnWidth }
+            space="x2"
             xAxisLabels={ xAxisLabels }
             zoomTo={ zoomValue }>
           { formattedData.map(({ values, benchmark, label }, index) =>

--- a/src/charts/vars.css
+++ b/src/charts/vars.css
@@ -6,7 +6,7 @@
 
 :root {
   --cmp-chart-label-margin: calc(var(--spacing-grid-size) * 2);
-  --cmp-chart-label-line-height: var(--line-height-body);  /* [1] */
+  --cmp-chart-label-line-height: 1rem;  /* [1] */
   --cmp-chart-label-width: calc(2rem + var(--cmp-chart-label-margin));  /* [1] */
   --cmp-chart-label-height: calc(var(--cmp-chart-label-line-height) + var(--cmp-chart-label-margin));
 


### PR DESCRIPTION
**feat(ChartTable):** Added configurable spacing between ChartTableRows and within the grid container. This can be configured from the BarChart with the `barSpace` property using spacing pattern `x1|x2|x3`. DotPlot rows are a fixed distance of `x2`

[Netlify example of the compact version](https://599d44a37960b13543f435c5--hhogg-axiom.netlify.com/docs/charts/bar-chart?state=%7B%22BarChart%22%3A%7B%22props%22%3A%7B%22rowSpace%22%3A%22x1%22%2C%22data%22%3A%5B%7B%22label%22%3A%22Family%20%26%20Parenting%22%2C%22benchmark%22%3A14%2C%22values%22%3A%7B%22blue%22%3A17%2C%22orange%22%3A30%7D%7D%2C%7B%22label%22%3A%22Food%20%26%20Drinks%22%2C%22benchmark%22%3A7%2C%22values%22%3A%7B%22blue%22%3A10%2C%22orange%22%3A22%7D%7D%2C%7B%22label%22%3A%22Music%22%2C%22benchmark%22%3A13%2C%22values%22%3A%7B%22blue%22%3A27%2C%22orange%22%3A15%7D%7D%2C%7B%22label%22%3A%22Animals%20%26%20Pets%22%2C%22benchmark%22%3A9%2C%22values%22%3A%7B%22blue%22%3A5%2C%22orange%22%3A11%7D%7D%2C%7B%22label%22%3A%22Beauty%2FHealth%20%26%20Fitness%22%2C%22benchmark%22%3A6%2C%22values%22%3A%7B%22blue%22%3A5%2C%22orange%22%3A11%7D%7D%2C%7B%22label%22%3A%22Games%22%2C%22benchmark%22%3A5%2C%22values%22%3A%7B%22blue%22%3A10%2C%22orange%22%3A5%7D%7D%2C%7B%22label%22%3A%22Business%22%2C%22benchmark%22%3A6%2C%22values%22%3A%7B%22blue%22%3A12%2C%22orange%22%3A10%7D%7D%2C%7B%22label%22%3A%22Books%22%2C%22benchmark%22%3A3%2C%22values%22%3A%7B%22blue%22%3A8%2C%22orange%22%3A12%7D%7D%2C%7B%22label%22%3A%22Travel%22%2C%22benchmark%22%3A3%2C%22values%22%3A%7B%22blue%22%3A3%2C%22orange%22%3A6%7D%7D%2C%7B%22label%22%3A%22Fashion%22%2C%22benchmark%22%3A6%2C%22values%22%3A%7B%22blue%22%3A2%2C%22orange%22%3A5%7D%7D%2C%7B%22label%22%3A%22Shopping%22%2C%22benchmark%22%3A3%2C%22values%22%3A%7B%22blue%22%3A2%2C%22orange%22%3A4%7D%7D%2C%7B%22label%22%3A%22Technology%22%2C%22benchmark%22%3A2%2C%22values%22%3A%7B%22blue%22%3A7%2C%22orange%22%3A6%7D%7D%2C%7B%22label%22%3A%22Environment%22%2C%22benchmark%22%3A5%2C%22values%22%3A%7B%22blue%22%3A1%2C%22orange%22%3A3%7D%7D%2C%7B%22label%22%3A%22Politics%22%2C%22benchmark%22%3A2%2C%22values%22%3A%7B%22blue%22%3A2%2C%22orange%22%3A1%7D%7D%2C%7B%22label%22%3A%22Movies%22%2C%22benchmark%22%3A3%2C%22values%22%3A%7B%22blue%22%3A5%2C%22orange%22%3A6%7D%7D%2C%7B%22label%22%3A%22Sports%22%2C%22benchmark%22%3A1%2C%22values%22%3A%7B%22blue%22%3A21%2C%22orange%22%3A21%7D%7D%2C%7B%22label%22%3A%22Fine%20arts%22%2C%22benchmark%22%3A2%2C%22values%22%3A%7B%22blue%22%3A6%2C%22orange%22%3A7%7D%7D%2C%7B%22label%22%3A%22TV%22%2C%22benchmark%22%3A5%2C%22values%22%3A%7B%22blue%22%3A6%2C%22orange%22%3A6%7D%7D%2C%7B%22label%22%3A%22Automotive%22%2C%22benchmark%22%3A1%2C%22values%22%3A%7B%22blue%22%3A3%2C%22orange%22%3A4%7D%7D%2C%7B%22label%22%3A%22Science%22%2C%22benchmark%22%3A2%2C%22values%22%3A%7B%22blue%22%3A2%2C%22orange%22%3A2%7D%7D%2C%7B%22label%22%3A%22Photo%20%26%20Video%22%2C%22benchmark%22%3A2%2C%22values%22%3A%7B%22blue%22%3A4%2C%22orange%22%3A4%7D%7D%5D%2C%22collapsedVisibleRowCount%22%3A6%7D%7D%7D)

[Netlify example of the expanded version](https://599d44a37960b13543f435c5--hhogg-axiom.netlify.com/docs/charts/bar-chart?state=%7B%22BarChart%22%3A%7B%22props%22%3A%7B%22rowSpace%22%3A%22x3%22%2C%22data%22%3A%5B%7B%22label%22%3A%22Family%20%26%20Parenting%22%2C%22benchmark%22%3A14%2C%22values%22%3A%7B%22blue%22%3A17%2C%22pink%22%3A15%2C%22orange%22%3A30%7D%7D%2C%7B%22label%22%3A%22Food%20%26%20Drinks%22%2C%22benchmark%22%3A7%2C%22values%22%3A%7B%22blue%22%3A10%2C%22pink%22%3A11%2C%22orange%22%3A22%7D%7D%5D%2C%22collapsedVisibleRowCount%22%3A6%2C%22size%22%3A%221.5rem%22%7D%7D%7D)