### PR TITLE
fix(Tabset): Upper casing not taking effect in Chrome and Safari

### DIFF
--- a/src/components/tabset/Tab.js
+++ b/src/components/tabset/Tab.js
@@ -28,7 +28,6 @@ export default class Tab extends Component {
       <Base { ...rest }
           Component="li"
           className={ classes }
-          textCase="upper"
           textSize="small"
           textStrong={ true }
           title={ title }>

--- a/src/components/tabset/Tabset.css
+++ b/src/components/tabset/Tabset.css
@@ -55,6 +55,7 @@
   border: 0;
   background: none;
   color: inherit;
+  text-transform: uppercase;
   line-height: var(--component-line-height);
   transition-property: color;
   transition-duration: var(--transition-time-base);


### PR DESCRIPTION
Due to the uppercasing being applied to the parent `<li>` rather than the `<button>`. 