### PR TITLE
fix(Grid): Correct typo in .ax-grid--horizontal-start

### DIFF
--- a/src/components/grid/Grid.css
+++ b/src/components/grid/Grid.css
@@ -22,7 +22,7 @@
 .ax-grid--vertical-middle { align-items: center; }
 .ax-grid--vertical-end    { align-items: flex-end; }
 
-.ax-grid--horionztal-start    { justify-content: flex-start; }
+.ax-grid--horizontal-start    { justify-content: flex-start; }
 .ax-grid--horizontal-middle   { justify-content: center; }
 .ax-grid--horizontal-end      { justify-content: flex-end; }
 .ax-grid--horizontal-around   { justify-content: space-around; }


### PR DESCRIPTION
Just a small fix for a typo.