### PR TITLE
chore(build): Add an ES modules build with a `module` field in the package.json to enable tree-shaking with Webpack

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
+  "plugins": [
+    "./scripts/babel-plugin-inline-svg-import.js",
+  ],
   "env": {
     "development": {
       "presets": [
@@ -6,20 +9,21 @@
         "stage-2",
         "react",
         "react-hmre",
-      ],
-      "plugins": [
-        "./scripts/babel-plugin-inline-svg-import.js",
-      ],
+      ]
     },
     "production": {
       "presets": [
         "es2015",
         "stage-2",
         "react",
-      ],
-      "plugins": [
-        "./scripts/babel-plugin-inline-svg-import.js",
-      ],
+      ]
+    },
+    "production-esm": {
+      "presets": [
+        ["es2015", {"modules": false}],
+        "stage-2",
+        "react",
+      ]
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+esm
 lib
 static
 tmp

--- a/deploy/travis_setup.sh
+++ b/deploy/travis_setup.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-rm -rf tmp
+rm -rf esm tmp
 mkdir tmp
 rsync -a --prune-empty-dirs --exclude 'example/*' src/* tmp
+cp -r tmp esm
+
 NODE_ENV=production BABEL_ENV=production node_modules/.bin/babel tmp --out-dir tmp
+
+NODE_ENV=production BABEL_ENV=production-esm node_modules/.bin/babel esm --out-dir esm

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Axiom - Brandwatch Pattern Library",
   "version": "0.0.0-development",
   "main": "./lib",
+  "module": "./esm",
   "license": "MIT",
   "homepage": "https://BrandwatchLtd.github.io/axiom",
   "bugs": {


### PR DESCRIPTION
Any projects that consume Axiom using Webpack will automatically find the ES modules build and tree-shake it to remove any unused components from the build!