### PR TITLE
Disable submit in the ChangePassword composite once the form has been submitted

### DIFF
--- a/src/composites/change-password/ChangePassword.js
+++ b/src/composites/change-password/ChangePassword.js
@@ -86,7 +86,7 @@ export default class ChangePassword extends Component {
 
     return (
       <Dialog { ...rest } onRequestClose={ onRequestClose } size="medium">
-        <DialogHeader onRequestClose={ onRequestClose }>
+        <DialogHeader>
           <Heading textSize="headtitle">
             Change Password
           </Heading>

--- a/src/composites/change-password/ChangePassword.js
+++ b/src/composites/change-password/ChangePassword.js
@@ -44,45 +44,8 @@ export default class ChangePassword extends Component {
     ],
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      currentPassword: '',
-      newPassword: '',
-      confirmPassword: '',
-    };
-
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.handlePasswordChange = this.handlePasswordChange.bind(this);
-  }
-
-  handlePasswordChange(key, event) {
-    this.setState({ [key]: event.target.value });
-  }
-
-  handleSubmit(event) {
-    event.preventDefault();
-    const { onSubmit } = this.props;
-    const { currentPassword, newPassword } = this.state;
-
-    onSubmit({ currentPassword, newPassword });
-  }
-
   render() {
-    const { onRequestClose, error, isSubmitting, rules, ...rest } = this.props;
-    const { currentPassword, newPassword, confirmPassword } = this.state;
-
-    const validatedRules = rules.map(rule => ({
-      ...rule,
-      valid: rule.pattern.test(newPassword),
-    }));
-
-    const allValid = validatedRules.every(({ valid }) => valid === true);
-    const passwordsMatch = currentPassword === newPassword;
-    const currentPasswordValid = currentPassword.length > 0;
-    const newPasswordValid = allValid && !passwordsMatch && newPassword.length > 0;
-    const confirmPasswordValid = newPasswordValid && newPassword === confirmPassword;
+    const { error, isSubmitting, onRequestClose, onSubmit, rules, ...rest } = this.props;
 
     return (
       <Dialog { ...rest } onRequestClose={ onRequestClose } size="medium">
@@ -102,16 +65,11 @@ export default class ChangePassword extends Component {
 
         <DialogBody>
           <ChangePasswordForm
-              confirmPassword={ confirmPassword }
-              confirmPasswordValid={ confirmPasswordValid }
-              currentPassword={ currentPassword }
-              isSubmitDisabled={ !confirmPasswordValid || !currentPasswordValid || isSubmitting }
-              newPassword={ newPassword }
-              newPasswordValid={ newPasswordValid }
+              isSubmitting={ isSubmitting }
               onCancel={ onRequestClose }
-              onPasswordChange={ this.handlePasswordChange }
-              onSubmit={ this.handleSubmit }
-              rules={ validatedRules } />
+              onRequestClose={ onRequestClose }
+              onSubmit={ onSubmit }
+              rules={ rules } />
         </DialogBody>
       </Dialog>
     );

--- a/src/composites/change-password/ChangePassword.js
+++ b/src/composites/change-password/ChangePassword.js
@@ -4,13 +4,11 @@ import {
   Alert,
   Dialog,
   DialogBody,
-  DialogFooter,
   DialogHeader,
   Paragraph,
   Heading,
 } from 'bw-axiom';
 import ChangePasswordForm from './ChangePasswordForm';
-import ChangePasswordControls from './ChangePasswordControls';
 import atIds from '../../../at_ids';
 
 export default class ChangePassword extends Component {
@@ -107,7 +105,6 @@ export default class ChangePassword extends Component {
               confirmPassword={ confirmPassword }
               confirmPasswordValid={ confirmPasswordValid }
               currentPassword={ currentPassword }
-              currentPasswordValid={ currentPasswordValid }
               submitDisabled={ !confirmPasswordValid || !currentPasswordValid || isSubmitting }
               newPassword={ newPassword }
               newPasswordValid={ newPasswordValid }

--- a/src/composites/change-password/ChangePassword.js
+++ b/src/composites/change-password/ChangePassword.js
@@ -20,6 +20,8 @@ export default class ChangePassword extends Component {
     error: PropTypes.string,
     /** Visibility toggle for the Dialog */
     isOpen: PropTypes.bool.isRequired,
+    /** Toggles the disabled property on the submit button */
+    isSubmitting: PropTypes.bool,
     /**
      * List of rules which the password must fulfill, contains a human friendly
      * label and associated pattern.
@@ -35,6 +37,7 @@ export default class ChangePassword extends Component {
   };
 
   static defaultProps = {
+    isSubmitting: false,
     rules: [
       { label: '8 characters', pattern: /^.{8,}$/ },
       { label: '1 numeric character', pattern: /^.*[0-9].*$/ },
@@ -69,7 +72,7 @@ export default class ChangePassword extends Component {
   }
 
   render() {
-    const { onRequestClose, error, rules, ...rest } = this.props;
+    const { onRequestClose, error, isSubmitting, rules, ...rest } = this.props;
     const { currentPassword, newPassword, confirmPassword } = this.state;
 
     const validatedRules = rules.map(rule => ({
@@ -105,18 +108,14 @@ export default class ChangePassword extends Component {
               confirmPasswordValid={ confirmPasswordValid }
               currentPassword={ currentPassword }
               currentPasswordValid={ currentPasswordValid }
+              submitDisabled={ !confirmPasswordValid || !currentPasswordValid || isSubmitting }
               newPassword={ newPassword }
               newPasswordValid={ newPasswordValid }
+              onCancel={ onRequestClose }
               onPasswordChange={ this.handlePasswordChange }
               onSubmit={ this.handleSubmit }
               rules={ validatedRules } />
         </DialogBody>
-        <DialogFooter>
-          <ChangePasswordControls
-              onCancel={ onRequestClose }
-              onSubmit={ this.handleSubmit }
-              submitDisabled={ !confirmPasswordValid || !currentPasswordValid } />
-        </DialogFooter>
       </Dialog>
     );
   }

--- a/src/composites/change-password/ChangePassword.js
+++ b/src/composites/change-password/ChangePassword.js
@@ -105,7 +105,7 @@ export default class ChangePassword extends Component {
               confirmPassword={ confirmPassword }
               confirmPasswordValid={ confirmPasswordValid }
               currentPassword={ currentPassword }
-              submitDisabled={ !confirmPasswordValid || !currentPasswordValid || isSubmitting }
+              isSubmitDisabled={ !confirmPasswordValid || !currentPasswordValid || isSubmitting }
               newPassword={ newPassword }
               newPasswordValid={ newPasswordValid }
               onCancel={ onRequestClose }

--- a/src/composites/change-password/ChangePasswordControls.js
+++ b/src/composites/change-password/ChangePasswordControls.js
@@ -9,13 +9,13 @@ import atIds from '../../../at_ids';
 export default class ChangePasswordControls extends Component {
 
   static propTypes = {
-    submitDisabled: PropTypes.bool.isRequired,
+    isSubmitDisabled: PropTypes.bool.isRequired,
     onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   };
 
   render() {
-    const { onSubmit, onCancel, submitDisabled } = this.props;
+    const { onSubmit, onCancel, isSubmitDisabled } = this.props;
 
     return (
       <ButtonGroup textRight>
@@ -28,7 +28,7 @@ export default class ChangePasswordControls extends Component {
         </Button>
         <Button
             data-ax-at={ atIds.ChangePassword.submit }
-            disabled={ submitDisabled }
+            disabled={ isSubmitDisabled }
             onClick={ onSubmit }
             type="submit">
           Change Password

--- a/src/composites/change-password/ChangePasswordControls.js
+++ b/src/composites/change-password/ChangePasswordControls.js
@@ -21,13 +21,16 @@ export default class ChangePasswordControls extends Component {
       <ButtonGroup textRight>
         <Button
             data-ax-at={ atIds.ChangePassword.cancel }
-            onClick={ () => onCancel() } style="secondary">
+            onClick={ () => onCancel() }
+            style="secondary"
+            type="button">
           Cancel
         </Button>
         <Button
             data-ax-at={ atIds.ChangePassword.submit }
             disabled={ submitDisabled }
-            onClick={ onSubmit }>
+            onClick={ onSubmit }
+            type="submit">
           Change Password
         </Button>
       </ButtonGroup>

--- a/src/composites/change-password/ChangePasswordForm.js
+++ b/src/composites/change-password/ChangePasswordForm.js
@@ -9,6 +9,7 @@ import {
   ListItem,
   TextInput,
 } from 'bw-axiom';
+import ChangePasswordControls from './ChangePasswordControls';
 import atIds from '../../../at_ids';
 
 export default class ChangePasswordForm extends Component {
@@ -17,12 +18,14 @@ export default class ChangePasswordForm extends Component {
     confirmPassword: PropTypes.string.isRequired,
     confirmPasswordValid: PropTypes.bool.isRequired,
     currentPassword: PropTypes.string.isRequired,
+    isSubmitDisabled: PropTypes.bool.isRequired,
     newPassword: PropTypes.string.isRequired,
     newPasswordValid: PropTypes.bool.isRequired,
     rules: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string.isRequired,
       valid: PropTypes.bool.isRequired,
     })),
+    onCancel: PropTypes.func.isRequired,
     onPasswordChange: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   };
@@ -34,8 +37,11 @@ export default class ChangePasswordForm extends Component {
       newPasswordValid,
       confirmPassword,
       confirmPasswordValid,
+      onCancel,
       onPasswordChange,
+      onSubmit,
       rules,
+      isSubmitDisabled,
     } = this.props;
 
     const colRules = [
@@ -44,7 +50,7 @@ export default class ChangePasswordForm extends Component {
     ];
 
     return (
-      <Form onSubmit={ e => this.handleSubmit(e) }>
+      <Form onSubmit={ onSubmit }>
         <TextInput
             data-ax-at={ atIds.ChangePassword.currentPassword }
             label="Enter current password"
@@ -91,6 +97,11 @@ export default class ChangePasswordForm extends Component {
             type="password"
             valid={ confirmPasswordValid }
             value={ confirmPassword } />
+
+        <ChangePasswordControls
+            isSubmitDisabled={ isSubmitDisabled }
+            onCancel={ onCancel }
+            onSubmit={ onSubmit } />
       </Form>
     );
   }

--- a/src/composites/change-password/ChangePasswordForm.js
+++ b/src/composites/change-password/ChangePasswordForm.js
@@ -17,7 +17,6 @@ export default class ChangePasswordForm extends Component {
     confirmPassword: PropTypes.string.isRequired,
     confirmPasswordValid: PropTypes.bool.isRequired,
     currentPassword: PropTypes.string.isRequired,
-    currentPasswordValid: PropTypes.bool.isRequired,
     newPassword: PropTypes.string.isRequired,
     newPasswordValid: PropTypes.bool.isRequired,
     rules: PropTypes.arrayOf(PropTypes.shape({
@@ -31,7 +30,6 @@ export default class ChangePasswordForm extends Component {
   render() {
     const {
       currentPassword,
-      currentPasswordValid,
       newPassword,
       newPasswordValid,
       confirmPassword,
@@ -53,7 +51,6 @@ export default class ChangePasswordForm extends Component {
             onChange={ e => onPasswordChange('currentPassword', e) }
             space="x6"
             type="password"
-            valid={ currentPasswordValid }
             value={ currentPassword } />
 
         <TextInput


### PR DESCRIPTION
This PR prevents the ChangePassword composite's submit button pressed multiple times when there is a in the form being re rendered with an error or being closed. 