### PR TITLE
fix(Dropdown): Retaining opened state when initially disabled.

### DIFF
--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -17,6 +17,10 @@ export default class Dropdown extends Component {
      */
     children: PropTypes.node.isRequired,
     /**
+     * Adds control to enable or disable showing the DropdownContent
+     */
+    enabled: PropTypes.bool,
+    /**
      * Controls the starting position around DropdownTarget in which the
      * DropdownContent will attempt to be placed. If that position is not available
      * due to collision, it will be placed according to the flip behaviour  until
@@ -33,6 +37,7 @@ export default class Dropdown extends Component {
   };
 
   static defaultProps = {
+    enabled: true,
     position: 'bottom',
     showArrow: true,
   };
@@ -51,7 +56,11 @@ export default class Dropdown extends Component {
   }
 
   open() {
-    this.setState({ isVisible: true });
+    const { enabled } = this.props;
+
+    if (enabled) {
+      this.setState({ isVisible: true });
+    }
   }
 
   close() {

--- a/src/components/position/Position.js
+++ b/src/components/position/Position.js
@@ -16,7 +16,7 @@ export default class Position extends Component {
      */
     children: PropTypes.array.isRequired,
     /**
-     * Adds control to conditional enable or disabled the positioning logic.
+     * Adds control to conditionally enable or disable the positioning logic.
      * Must be true for isVisible to take effect.
      */
     enabled: PropTypes.bool,

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -17,12 +17,16 @@ export default class Tooltip extends Component {
      */
     children: PropTypes.node,
     /**
+     * Adds control to enable or disable showing the TooltipContent
+     */
+    enabled: PropTypes.bool,
+    /**
      * Controls the starting position around TooltipTarget in which the
      * TooltipContent will attempt to be placed. If that position is not available
      * due to collision, it will be placed according to the flip behaviour  until
      * a valid position is found.
      */
-    position: PropTypes.string,
+    position: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
   };
 
   static childContextTypes = {
@@ -31,6 +35,7 @@ export default class Tooltip extends Component {
   };
 
   static defaultProps = {
+    enabled: true,
     position: 'top',
   };
 
@@ -48,9 +53,10 @@ export default class Tooltip extends Component {
   }
 
   show() {
+    const { enabled } = this.props;
     const { isVisible } = this.state;
 
-    if (!isVisible) {
+    if (enabled && !isVisible) {
       this.setState({ isVisible: true });
     }
   }


### PR DESCRIPTION
When Dropdown was disabled (using the enabled prop on Position) it would still set the visible state when clicked, and could not be taken out of the visible state because no mask had been added because it was disabled.