### PR TITLE
fix(ContextBox): Ensure separator is still present when no padding is…

### DIFF
--- a/src/components/context/ContextBox.css
+++ b/src/components/context/ContextBox.css
@@ -23,6 +23,7 @@
   left: var(--cmp-context-padding-small);
 }
 
+.ax-context-box--padding-none::after,
 .ax-context-box--padding-large::after {
   right: var(--cmp-context-padding-large);
   left: var(--cmp-context-padding-large);


### PR DESCRIPTION
… specified - bug introduced in d2a1621590616e61098fa66f315f507b0f74f566

Before:
![screen shot 2017-09-25 at 11 23 00](https://user-images.githubusercontent.com/8782055/30804077-ee1856b6-a1e3-11e7-9600-e3cf358ba7bb.png)
After:
![screen shot 2017-09-25 at 11 23 07](https://user-images.githubusercontent.com/8782055/30804081-efb21106-a1e3-11e7-8163-b6adfc0dd90f.png)

This affects ContextMenu and DropdownMenu which both depend on this component