### PR TITLE
fix(Buttons): Rounded buttons in Chrome.

### DIFF
--- a/src/components/base/globals.css
+++ b/src/components/base/globals.css
@@ -48,6 +48,7 @@ textarea {
 /* normalise button styles */
 button {
   margin: 0;
+  border-radius: 0;
   font: inherit;
 
   /* Remove the inner border and padding in Firefox. */


### PR DESCRIPTION
Google Chrome made the decision to edit their user agent stylesheet for OSX Chrome and add rounded buttons. This caused all unstyled buttons on the internet to have rounded corners. They have since reverted that change, but is not due to be released for a few months.

Further reading
https://www.chromestatus.com/features/5743649186906112
https://bugs.chromium.org/p/chromium/issues/detail?id=752450#c13