### PR TITLE
feat(Cloak): Added base property and alias components for consistent …

### DIFF
--- a/src/components/base/Base.css
+++ b/src/components/base/Base.css
@@ -128,3 +128,17 @@
   position: sticky;
   z-index: var(--z-index-sticky);
 }
+
+.ax-cloak {
+  opacity: 0;
+  transition-property: opacity;
+  transition-duration: var(--transition-time-base);
+  transition-timing-function: var(--transition-function);
+  pointer-events: none;
+
+  @nest .ax-cloak__container:hover &,
+  &.ax-cloak--visible {
+    opacity: 1;
+    pointer-events: all;
+  }
+}

--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -25,6 +25,10 @@ export default class Base extends Component {
     ]),
     /** Class name to be appended to the element */
     className: PropTypes.string,
+    /** Adds ability to make an element invisible */
+    cloak: PropTypes.bool,
+    /** Adds the ability control the visibility of a child cloaked element */
+    cloakContainer: PropTypes.bool,
     /**
      * Control over when the element should be hidden until.
      * Opposite of `visibleUntil`.
@@ -104,6 +108,8 @@ export default class Base extends Component {
     const {
       Component,
       className,
+      cloak,
+      cloakContainer,
       hiddenUntil,
       space,
       sticky,
@@ -127,6 +133,9 @@ export default class Base extends Component {
     const underline = textUnderline &&
       underlineTextSizes.has(textSize || 'body') && (textSize || 'body');
     const classes = classnames(className, {
+      'ax-cloak': cloak !== undefined,
+      'ax-cloak--visible': cloak === false,
+      'ax-cloak__container': cloakContainer,
       [`ax-hidden-until--${hiddenUntil}`]: hiddenUntil,
       [`ax-visible-until--${visibleUntil}`]: visibleUntil,
       [`ax-space--${space}`]: space,

--- a/src/components/base/Base.test.js
+++ b/src/components/base/Base.test.js
@@ -47,6 +47,22 @@ describe('Base', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  describe('renders cloak', () =>
+    [undefined, true, false].forEach((cloak) =>
+      it(cloak, () => {
+        const component = getComponent({ cloak });
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      })
+    )
+  );
+
+  it('renders cloakContainer', () => {
+    const component = getComponent({ cloakContainer: true });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   describe('renders with hiddenUntil', () => {
     ['small', 'medium', 'large'].forEach((hiddenUntil) => {
       it(hiddenUntil, () => {

--- a/src/components/base/__snapshots__/Base.test.js.snap
+++ b/src/components/base/__snapshots__/Base.test.js.snap
@@ -8,6 +8,30 @@ exports[`Base renders className 1`] = `
 />
 `;
 
+exports[`Base renders cloak  1`] = `
+<div
+  className=""
+/>
+`;
+
+exports[`Base renders cloak  2`] = `
+<div
+  className="ax-cloak ax-cloak--visible"
+/>
+`;
+
+exports[`Base renders cloak true 1`] = `
+<div
+  className="ax-cloak"
+/>
+`;
+
+exports[`Base renders cloakContainer 1`] = `
+<div
+  className="ax-cloak__container"
+/>
+`;
+
 exports[`Base renders functional Component 1`] = `<span />`;
 
 exports[`Base renders sticky with style 1`] = `

--- a/src/components/cloak/Cloak.js
+++ b/src/components/cloak/Cloak.js
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Base from '../base/Base';
+
+export default class Cloak extends Component {
+  static propTypes = {
+    /**
+     * Programmatic control over the invisibility of the cloak, as opposed
+     * to using the CloakContainer
+     */
+    invisible: PropTypes.bool,
+  };
+
+  render() {
+    const { invisible, ...rest } = this.props;
+
+    return (
+      <Base cloak={ invisible } { ...rest } />
+    );
+  }
+}

--- a/src/components/cloak/Cloak.test.js
+++ b/src/components/cloak/Cloak.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Cloak from './Cloak';
+
+const getComponent = (props = {}) =>
+  renderer.create(
+    <Cloak { ...props }>
+      Lorem Ipsum
+    </Cloak>
+  );
+
+describe('Cloak', () => {
+  it('renders with defaultProps', () => {
+    const component = getComponent();
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders invisible true', () => {
+    const component = getComponent({ invisible: true });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders invisible false', () => {
+    const component = getComponent({ invisible: false });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/cloak/CloakContainer.js
+++ b/src/components/cloak/CloakContainer.js
@@ -1,0 +1,10 @@
+import React, { Component } from 'react';
+import Base from '../base/Base';
+
+export default class CloakContainer extends Component {
+  render() {
+    return (
+      <Base cloakContainer { ...this.props } />
+    );
+  }
+}

--- a/src/components/cloak/CloakContainer.test.js
+++ b/src/components/cloak/CloakContainer.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import CloakContainer from './CloakContainer';
+
+const getComponent = (props = {}) =>
+  renderer.create(
+    <CloakContainer { ...props }>
+      Lorem Ipsum
+    </CloakContainer>
+  );
+
+describe('CloakContainer', () => {
+  it('renders with defaultProps', () => {
+    const component = getComponent();
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/cloak/__snapshots__/Cloak.test.js.snap
+++ b/src/components/cloak/__snapshots__/Cloak.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cloak renders invisible false 1`] = `
+<div
+  className="ax-cloak ax-cloak--visible"
+>
+  Lorem Ipsum
+</div>
+`;
+
+exports[`Cloak renders invisible true 1`] = `
+<div
+  className="ax-cloak"
+>
+  Lorem Ipsum
+</div>
+`;
+
+exports[`Cloak renders with defaultProps 1`] = `
+<div
+  className=""
+>
+  Lorem Ipsum
+</div>
+`;

--- a/src/components/cloak/__snapshots__/CloakContainer.test.js.snap
+++ b/src/components/cloak/__snapshots__/CloakContainer.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CloakContainer renders with defaultProps 1`] = `
+<div
+  className="ax-cloak__container"
+>
+  Lorem Ipsum
+</div>
+`;

--- a/src/components/cloak/example/index.js
+++ b/src/components/cloak/example/index.js
@@ -1,0 +1,101 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { ExampleConfig } from 'style-guide';
+import Candytar from '../../candytar/Candytar';
+import Card from '../../card/Card';
+import CardList from '../../card/CardList';
+import Cloak from '../Cloak';
+import Context from '../../context/Context';
+import Dropdown from '../../dropdown/Dropdown';
+import DropdownContent from '../../dropdown/DropdownContent';
+import DropdownMenu from '../../dropdown/DropdownMenu';
+import DropdownMenuItem from '../../dropdown/DropdownMenuItem';
+import DropdownTarget from '../../dropdown/DropdownTarget';
+import Grid from '../../grid/Grid';
+import GridCell from '../../grid/GridCell';
+import Heading from '../../typography/Heading';
+import IconButton from '../../icon/IconButton';
+import Paragraph from '../../typography/Paragraph';
+
+class CloakExample extends Component {
+  static propTypes = {
+    components: PropTypes.shape({
+      Cloak: PropTypes.object.isRequired,
+      CloakContainer: PropTypes.object.isRequired,
+    }).isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false,
+    };
+  }
+
+  render() {
+    const { isOpen } = this.state;
+    const { components } = this.props;
+
+    const propTypes = {
+      Cloak: components.Cloak,
+      CloakContainer: components.CloakContainer,
+    };
+
+    const initialProps = {
+      Cloak: {
+        invisible: !isOpen,
+      },
+      CloakContainer: {},
+    };
+
+    return (
+      <ExampleConfig
+          initialProps={ initialProps }
+          propTypes={ propTypes }>
+        <CardList cloakContainer>
+          <Card active={ isOpen } cloakContainer onClick={ () => {} }>
+            <Grid responsive={ false } snippetReplace verticalAlign="middle">
+              <GridCell shrink>
+                <Candytar color="lilac" size="4.5rem" />
+              </GridCell>
+
+              <GridCell>
+                <Heading textSize="headtitle">Lorem Ipsum</Heading>
+                <Paragraph>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Nunc commodo egestas fringilla. In a arcu erat. Ut vestibulum
+                  sollicitudin orci, ut blandit ante. Vestibulum tempus rhoncus
+                  vehicula.
+                </Paragraph>
+              </GridCell>
+
+              <GridCell shrink>
+                <Dropdown
+                    onRequestClose={ () => this.setState({ isOpen: false }) }
+                    onRequestOpen={ () => this.setState({ isOpen: true }) }>
+                  <DropdownTarget>
+                    <Cloak { ...initialProps.Cloak }>
+                      <IconButton name="ellipsis" />
+                    </Cloak>
+                  </DropdownTarget>
+
+                  <DropdownContent { ...initialProps.DropdownContent }>
+                    <Context>
+                      <DropdownMenu { ...initialProps.DropdownMenu }>
+                        <DropdownMenuItem { ...initialProps.DropdownMenuItem }>
+                          Lorem ipsum
+                        </DropdownMenuItem>
+                      </DropdownMenu>
+                    </Context>
+                  </DropdownContent>
+                </Dropdown>
+              </GridCell>
+            </Grid>
+          </Card>
+        </CardList>
+      </ExampleConfig>
+    );
+  }
+}
+
+export default [ CloakExample ];

--- a/src/components/context/ContextMenuItem.css
+++ b/src/components/context/ContextMenuItem.css
@@ -41,12 +41,4 @@
 .ax-context-menu__item-icon {
   flex: 0 0 auto;
   margin-left: var(--spacing-grid-size--x2);
-  opacity: 0;
-  transition-property: opacity;
-  transition-duration: var(--transition-time-base);
-  transition-timing-function: var(--transition-function);
-
-  @nest .ax-context-menu__item-single--selected & {
-    opacity: 1;
-  }
 }

--- a/src/components/context/ContextMenuItemSingle.js
+++ b/src/components/context/ContextMenuItemSingle.js
@@ -23,7 +23,7 @@ export default class ContextMenuItemSingle extends Component {
 
         { selected !== undefined && (
           <div className="ax-context-menu__item-icon">
-            <Icon name="tick" />
+            <Icon cloak={ !selected } name="tick" />
           </div>
         ) }
       </button>

--- a/src/components/context/__snapshots__/ContextMenuItem.test.js.snap
+++ b/src/components/context/__snapshots__/ContextMenuItem.test.js.snap
@@ -156,7 +156,7 @@ exports[`ContextMenuItem renders with selected 1`] = `
       className="ax-context-menu__item-icon"
     >
       <svg
-        className="ax-icon ax-icon--tick"
+        className="ax-icon ax-icon--tick ax-cloak ax-cloak--visible"
         dangerouslySetInnerHTML={
           Object {
             "__html": "<path d=\\"M3.25 8.25L6 11l6.75-6.75\\" fill-rule=\\"nonzero\\" stroke=\\"currentColor\\" stroke-width=\\"2.1\\" fill=\\"none\\"/>",

--- a/src/components/data-picker/DataPickerHeader.css
+++ b/src/components/data-picker/DataPickerHeader.css
@@ -13,14 +13,3 @@
   flex: 0 0 auto;
   margin-left: calc(var(--spacing-grid-size) * 2);
 }
-
-.ax-data-picker__header-link {
-  opacity: 0;
-  transition-property: opacity;
-  transition-duration: var(--transition-time-base);
-  transition-timing-function: var(--transition-function);
-
-  @nest .ax-data-picker__header:hover & {
-    opacity: 1;
-  }
-}

--- a/src/components/data-picker/DataPickerHeader.js
+++ b/src/components/data-picker/DataPickerHeader.js
@@ -51,7 +51,7 @@ export default class DataPickerHeader extends Component {
     const title = value || placeholder;
 
     return (
-      <PanelHeader { ...rest }>
+      <PanelHeader { ...rest } cloakContainer>
         <div className="ax-data-picker__header">
           <Grid
               gutters="tiny"
@@ -103,12 +103,10 @@ export default class DataPickerHeader extends Component {
             </GridCell>
 
             { onClear && value && (
-              <GridCell shrink>
-                <span className="ax-data-picker__header-link">
-                  <Link onClick={ onClear }>
-                    <Strong><Small textCase="upper">{ t(axiomLanguage, 'clear') }</Small></Strong>
-                  </Link>
-                </span>
+              <GridCell cloak shrink>
+                <Link onClick={ onClear }>
+                  <Strong><Small textCase="upper">{ t(axiomLanguage, 'clear') }</Small></Strong>
+                </Link>
               </GridCell>
             ) }
           </Grid>

--- a/src/components/data-picker/__snapshots__/DataPickerHeader.test.js.snap
+++ b/src/components/data-picker/__snapshots__/DataPickerHeader.test.js.snap
@@ -10,7 +10,7 @@ exports[`DataPickerHeader renders with color 1`] = `
   }
 >
   <div
-    className="ax-panel__header"
+    className="ax-panel__header ax-cloak__container"
   >
     <div
       className="ax-data-picker__header"
@@ -71,7 +71,7 @@ exports[`DataPickerHeader renders with defaultProps 1`] = `
   }
 >
   <div
-    className="ax-panel__header"
+    className="ax-panel__header ax-cloak__container"
   >
     <div
       className="ax-data-picker__header"
@@ -132,7 +132,7 @@ exports[`DataPickerHeader renders with onClear 1`] = `
   }
 >
   <div
-    className="ax-panel__header"
+    className="ax-panel__header ax-cloak__container"
   >
     <div
       className="ax-data-picker__header"
@@ -193,7 +193,7 @@ exports[`DataPickerHeader renders with value 1`] = `
   }
 >
   <div
-    className="ax-panel__header"
+    className="ax-panel__header ax-cloak__container"
   >
     <div
       className="ax-data-picker__header"

--- a/src/components/panel/PanelHeader.js
+++ b/src/components/panel/PanelHeader.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import Base from '../base/Base';
 
 export default class PanelHeader extends Component {
   static propTypes = {
@@ -10,9 +11,9 @@ export default class PanelHeader extends Component {
     const { children, ...rest } = this.props;
 
     return (
-      <div { ...rest } className="ax-panel__header">
+      <Base { ...rest } className="ax-panel__header">
         { children }
-      </div>
+      </Base>
     );
   }
 }

--- a/src/components/progress/ProgressButton.css
+++ b/src/components/progress/ProgressButton.css
@@ -2,32 +2,17 @@
   position: relative;
 }
 
-.ax-progress-button__content {
-  opacity: 1;
-  transition-property: opacity;
-  transition-duration: var(--transition-time-base);
-  transition-timing-function: var(--transition-function);
-}
-
 .ax-progress-button__indicator {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) scale(0);
   transform-origin: center;
-  opacity: 0;
-  transition-property: opacity, transform;
+  transition-property: transform;
   transition-duration: var(--transition-time-base);
   transition-timing-function: var(--transition-function);
-}
 
-.ax-progress-button--in-progress {
-  & .ax-progress-button__content {
-    opacity: 0;
-  }
-
-  & .ax-progress-button__indicator {
+  @nest .ax-progress-button--in-progress & {
     transform: translate(-50%, -50%) scale(1);
-    opacity: 1;
   }
 }

--- a/src/components/progress/ProgressButton.js
+++ b/src/components/progress/ProgressButton.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import Button from '../button/Button';
+import Cloak from '../cloak/Cloak';
 import ProgressInfinite from './ProgressInfinite';
 import './ProgressButton.css';
 
@@ -39,15 +40,19 @@ export default class ProgressButton extends Component {
           size={ size }
           style="primary">
         <div className={ classes }>
-          <div className="ax-progress-button__content">
+          <Cloak
+              className="ax-progress-button__content"
+              invisible={ isInProgress }>
             { children }
-          </div>
+          </Cloak>
 
-          <div className="ax-progress-button__indicator">
+          <Cloak
+              className="ax-progress-button__indicator"
+              invisible={ !isInProgress }>
             <ProgressInfinite
                 color="white"
                 sizeRem={ progressSizeMap[size] } />
-          </div>
+          </Cloak>
         </div>
       </Button>
     );

--- a/src/components/progress/__snapshots__/ProgressButton.test.js.snap
+++ b/src/components/progress/__snapshots__/ProgressButton.test.js.snap
@@ -14,7 +14,7 @@ exports[`ProgressButton renders with defaultProps 1`] = `
       Lorem
     </div>
     <div
-      className="ax-progress-button__indicator"
+      className="ax-progress-button__indicator ax-cloak"
     >
       <svg
         className="ax-progress-infinite ax-progress-infinite--white ax-radial-progress ax-radial-progress--small"
@@ -57,12 +57,12 @@ exports[`ProgressButton renders with isInProgress 1`] = `
     className="ax-progress-button ax-progress-button--in-progress"
   >
     <div
-      className="ax-progress-button__content"
+      className="ax-progress-button__content ax-cloak"
     >
       Lorem
     </div>
     <div
-      className="ax-progress-button__indicator"
+      className="ax-progress-button__indicator ax-cloak ax-cloak--visible"
     >
       <svg
         className="ax-progress-infinite ax-progress-infinite--white ax-radial-progress ax-radial-progress--small"
@@ -110,7 +110,7 @@ exports[`ProgressButton renders with size large 1`] = `
       Lorem
     </div>
     <div
-      className="ax-progress-button__indicator"
+      className="ax-progress-button__indicator ax-cloak"
     >
       <svg
         className="ax-progress-infinite ax-progress-infinite--white ax-radial-progress ax-radial-progress--small"
@@ -158,7 +158,7 @@ exports[`ProgressButton renders with size medium 1`] = `
       Lorem
     </div>
     <div
-      className="ax-progress-button__indicator"
+      className="ax-progress-button__indicator ax-cloak"
     >
       <svg
         className="ax-progress-infinite ax-progress-infinite--white ax-radial-progress ax-radial-progress--small"
@@ -206,7 +206,7 @@ exports[`ProgressButton renders with size small 1`] = `
       Lorem
     </div>
     <div
-      className="ax-progress-button__indicator"
+      className="ax-progress-button__indicator ax-cloak"
     >
       <svg
         className="ax-progress-infinite ax-progress-infinite--white ax-radial-progress ax-radial-progress--small"

--- a/src/components/table/TableHeaderLabel.js
+++ b/src/components/table/TableHeaderLabel.js
@@ -35,14 +35,12 @@ export default class TableHeaderLabel extends Component {
       ...rest
     } = this.props;
 
-    const isSelected = Boolean(sortDirection);
-
     const className = classnames(
       'ax-table__header-label',
       `ax-table__header-label--align-${textAlign}`,
       {
         'ax-table__header-label--grow': grow,
-        'ax-table__header-label--selected': isSelected,
+        'ax-table__header-label--selected': sortDirection !== undefined,
         'ax-table__header-label--shrink': shrink,
       }
     );
@@ -53,13 +51,14 @@ export default class TableHeaderLabel extends Component {
             className="ax-table__header-button"
             disabled={ !onClick }
             onClick={ onClick }>
-          {children}
-          <span style={ { opacity: Number(Boolean(sortDirection)) } }>
-            <TextIcon
-                name={ sortDirection === 'descending' ? 'triangle-down' : 'triangle-up' }
-                spaceLeft={ textAlign === 'left' ? 'x2' : undefined }
-                spaceRight={ textAlign === 'right' ? 'x2' : undefined } />
-          </span>
+
+          { children }
+
+          <TextIcon
+              cloak={ sortDirection === undefined }
+              name={ sortDirection === 'descending' ? 'triangle-down' : 'triangle-up' }
+              spaceLeft={ textAlign === 'left' ? 'x2' : undefined }
+              spaceRight={ textAlign === 'right' ? 'x2' : undefined } />
         </button>
       </Base>
     );

--- a/src/components/table/__snapshots__/TableHeader.test.js.snap
+++ b/src/components/table/__snapshots__/TableHeader.test.js.snap
@@ -14,29 +14,21 @@ exports[`TableHeader renders 1`] = `
         onClick={undefined}
       >
         Test
-        <span
-          style={
+        <svg
+          className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2 ax-cloak"
+          dangerouslySetInnerHTML={
             Object {
-              "opacity": 0,
+              "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
             }
           }
-        >
-          <svg
-            className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
-              }
+          style={
+            Object {
+              "height": "1rem",
+              "width": "1rem",
             }
-            style={
-              Object {
-                "height": "1rem",
-                "width": "1rem",
-              }
-            }
-            viewBox="0 0 16 16"
-          />
-        </span>
+          }
+          viewBox="0 0 16 16"
+        />
       </button>
     </th>
   </tr>

--- a/src/components/table/__snapshots__/TableHeaderLabel.test.js.snap
+++ b/src/components/table/__snapshots__/TableHeaderLabel.test.js.snap
@@ -10,29 +10,21 @@ exports[`TableHeaderLabel renders 1`] = `
     onClick={undefined}
   >
     Test
-    <span
-      style={
+    <svg
+      className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2 ax-cloak"
+      dangerouslySetInnerHTML={
         Object {
-          "opacity": 0,
+          "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
         }
       }
-    >
-      <svg
-        className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
-          }
+      style={
+        Object {
+          "height": "1rem",
+          "width": "1rem",
         }
-        style={
-          Object {
-            "height": "1rem",
-            "width": "1rem",
-          }
-        }
-        viewBox="0 0 16 16"
-      />
-    </span>
+      }
+      viewBox="0 0 16 16"
+    />
   </button>
 </th>
 `;
@@ -47,29 +39,21 @@ exports[`TableHeaderLabel renders with grow 1`] = `
     onClick={undefined}
   >
     Test
-    <span
-      style={
+    <svg
+      className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2 ax-cloak"
+      dangerouslySetInnerHTML={
         Object {
-          "opacity": 0,
+          "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
         }
       }
-    >
-      <svg
-        className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
-          }
+      style={
+        Object {
+          "height": "1rem",
+          "width": "1rem",
         }
-        style={
-          Object {
-            "height": "1rem",
-            "width": "1rem",
-          }
-        }
-        viewBox="0 0 16 16"
-      />
-    </span>
+      }
+      viewBox="0 0 16 16"
+    />
   </button>
 </th>
 `;
@@ -84,29 +68,21 @@ exports[`TableHeaderLabel renders with shrink 1`] = `
     onClick={undefined}
   >
     Test
-    <span
-      style={
+    <svg
+      className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2 ax-cloak"
+      dangerouslySetInnerHTML={
         Object {
-          "opacity": 0,
+          "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
         }
       }
-    >
-      <svg
-        className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
-          }
+      style={
+        Object {
+          "height": "1rem",
+          "width": "1rem",
         }
-        style={
-          Object {
-            "height": "1rem",
-            "width": "1rem",
-          }
-        }
-        viewBox="0 0 16 16"
-      />
-    </span>
+      }
+      viewBox="0 0 16 16"
+    />
   </button>
 </th>
 `;
@@ -121,29 +97,21 @@ exports[`TableHeaderLabel renders with sortDirection 1`] = `
     onClick={undefined}
   >
     Test
-    <span
-      style={
+    <svg
+      className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2 ax-cloak ax-cloak--visible"
+      dangerouslySetInnerHTML={
         Object {
-          "opacity": 1,
+          "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
         }
       }
-    >
-      <svg
-        className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
-          }
+      style={
+        Object {
+          "height": "1rem",
+          "width": "1rem",
         }
-        style={
-          Object {
-            "height": "1rem",
-            "width": "1rem",
-          }
-        }
-        viewBox="0 0 16 16"
-      />
-    </span>
+      }
+      viewBox="0 0 16 16"
+    />
   </button>
 </th>
 `;
@@ -158,29 +126,21 @@ exports[`TableHeaderLabel renders with textAlign 1`] = `
     onClick={undefined}
   >
     Test
-    <span
-      style={
+    <svg
+      className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-right-x2 ax-cloak"
+      dangerouslySetInnerHTML={
         Object {
-          "opacity": 0,
+          "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
         }
       }
-    >
-      <svg
-        className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-right-x2"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
-          }
+      style={
+        Object {
+          "height": "1rem",
+          "width": "1rem",
         }
-        style={
-          Object {
-            "height": "1rem",
-            "width": "1rem",
-          }
-        }
-        viewBox="0 0 16 16"
-      />
-    </span>
+      }
+      viewBox="0 0 16 16"
+    />
   </button>
 </th>
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,8 @@ export { default as Card } from './components/card/Card';
 export { default as CardList } from './components/card/CardList';
 export { default as CheckBox } from './components/form/CheckBox';
 export { default as CheckBoxGroup } from './components/form/CheckBoxGroup';
+export { default as Cloak } from './components/cloak/Cloak';
+export { default as CloakContainer } from './components/cloak/CloakContainer';
 export { default as ColorPicker } from './components/color-picker/ColorPicker';
 export { default as ColorPickerOption } from './components/color-picker/ColorPickerOption';
 export { default as Console } from './components/platform/Console';

--- a/style-guide/map-documentation.js
+++ b/style-guide/map-documentation.js
@@ -21,6 +21,7 @@ module.exports = {
           'button': { name: 'Buttons' },
           'candytar': { name: 'Candytar' },
           'card': { name: 'Cards' },
+          'cloak': { name: 'Cloak' },
           'color-picker': { name: 'Color Picker' },
           'context': { name: 'Context' },
           'data-picker': { name: 'Data Picker' },

--- a/style-guide/map-examples.js
+++ b/style-guide/map-examples.js
@@ -11,6 +11,7 @@ export default {
   '/docs/components/button': require('../src/components/button/example').default,
   '/docs/components/candytar': require('../src/components/candytar/example').default,
   '/docs/components/card': require('../src/components/card/example').default,
+  '/docs/components/cloak': require('../src/components/cloak/example').default,
   '/docs/components/color-picker': require('../src/components/color-picker/example').default,
   '/docs/components/context': require('../src/components/context/example').default,
   '/docs/components/data-picker': require('../src/components/data-picker/example').default,


### PR DESCRIPTION
…cloaking ability

I've seen multiple places across every project using Axiom with the behaviour of hiding an element like a button inside a row and then hovering over the row reveals it (with transition) or when a menu is open on that button remaining visible. 

At the moment it's done by wrapping in an element, with a class on the element to be hidden and a class on the container to do the showing... but sometimes the transitions are being left off and not meeting the design requirements. 

This adds the behaviour to the Base class so it can be used like ... 

```jsx
<Card cloakContainer>
  <Grid>
    <GridCell>...</GridCell>
    <GridCell cloak={ !isOpen } shrink>
      <IconButton 
        name="ellipsis"
        onClick={ () => this.setState(({ isOpen }) => ({ isOpen: !isOpen })) } />
    </GridCell>
  </Grid>
</Card>
```

This will hide the button when `isOpen` is `false` and will show it when the `<Card>` is `:hover`ed and/or when `isOpen` is `true`.

I've also added some alias components `<Cloak invisible={ true }>` and `<CloakContainer>` where adding the base properties might interfere with other styles on the same element.

> [Netlify Link](https://cloak--hhogg-axiom.netlify.com/docs/components/cloak)