### PR TITLE
docs(readme): Fix broken link to IE support docs and use casing that …

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add bw-axiom
 
 ### [Supported Browsers](./browsers.js)
 
-Need IE Support? [See the the setup guide here]('./docs/internet-explorer.md')
+Need IE support? [See the the setup guide here](./docs/internet-explorer.md)
 
 ### Getting Started
 


### PR DESCRIPTION
…is consistent with the other docs links

Three guesses why I've been cribbing IE support! 😂 