### PR TITLE
fix(TableHeaderLabel): adds ability to declare a column as unsortable…

### DIFF
--- a/src/components/table/TableHeaderLabel.js
+++ b/src/components/table/TableHeaderLabel.js
@@ -16,12 +16,16 @@ export default class TableHeaderLabel extends Component {
     shrink: PropTypes.bool,
     /** Selects the column and sets the sort direction */
     sortDirection: PropTypes.oneOf(['ascending', 'descending']),
+    /** Indicates the column is sortable if false it will remove the cloaked icon
+    indicating sort direction */
+    sortable: PropTypes.bool,
     /** Set text-align */
     textAlign: PropTypes.oneOf(['left', 'right']),
   };
 
   static defaultProps = {
     textAlign: 'left',
+    sortable: true,
   }
 
   render() {
@@ -32,6 +36,7 @@ export default class TableHeaderLabel extends Component {
       shrink,
       sortDirection,
       textAlign,
+      sortable,
       ...rest
     } = this.props;
 
@@ -54,11 +59,12 @@ export default class TableHeaderLabel extends Component {
 
           { children }
 
-          <TextIcon
+          { sortable && ( <TextIcon
               cloak={ sortDirection === undefined }
               name={ sortDirection === 'descending' ? 'triangle-down' : 'triangle-up' }
               spaceLeft={ textAlign === 'left' ? 'x2' : undefined }
               spaceRight={ textAlign === 'right' ? 'x2' : undefined } />
+          ) }
         </button>
       </Base>
     );

--- a/src/components/table/TableHeaderLabel.test.js
+++ b/src/components/table/TableHeaderLabel.test.js
@@ -36,4 +36,10 @@ describe('TableHeaderLabel', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders with sortable', () => {
+    const component = getComponent({ sortable: false });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/components/table/__snapshots__/TableHeaderLabel.test.js.snap
+++ b/src/components/table/__snapshots__/TableHeaderLabel.test.js.snap
@@ -116,6 +116,20 @@ exports[`TableHeaderLabel renders with sortDirection 1`] = `
 </th>
 `;
 
+exports[`TableHeaderLabel renders with sortable 1`] = `
+<th
+  className="ax-table__header-label ax-table__header-label--align-left"
+>
+  <button
+    className="ax-table__header-button"
+    disabled={true}
+    onClick={undefined}
+  >
+    Test
+  </button>
+</th>
+`;
+
 exports[`TableHeaderLabel renders with textAlign 1`] = `
 <th
   className="ax-table__header-label ax-table__header-label--align-right"


### PR DESCRIPTION
… in order to remove cloaked sorting icon

https://5a5f74c0a6188f16f35500b2--librarian-chimpanzee-34483.netlify.com/docs/components/table?state=%7B%22TableHeaderLabel%22%3A%7B%22props%22%3A%7B%22sortable%22%3Afalse%7D%7D%7D