### PR TITLE
fix(Tabs): Prevent breaking across multuple lines

### DIFF
--- a/src/components/tabset/Tabset.css
+++ b/src/components/tabset/Tabset.css
@@ -2,6 +2,8 @@
   display: flex;
   align-items: flex-end;
   padding: 0;
+  white-space: nowrap;
+  overflow: auto;
 
   &::after {
     content: '';


### PR DESCRIPTION
There's definitely a more elegant solution for responsive tabs, this a quick fix to simply scroll horizontally when there's not enough room. 