### PR TITLE
fix(TextInput): Use Base under the hood to allow base props to be applied. 

### DIFF
--- a/src/components/form/TextInput.js
+++ b/src/components/form/TextInput.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
+import Base from '../base/Base';
 import TextInputIcon, { TextInputIconRef } from './TextInputIcon';
 import { TextInputButtonRef } from './TextInputButton';
 import TextGroup from './TextGroup';
@@ -130,7 +131,8 @@ export default class TextInput extends Component {
                   ) : icon
                 }
 
-                <input { ...rest }
+                <Base { ...rest }
+                    Component="input"
                     className="ax-input"
                     disabled={ disabled }
                     onBlur={ () => this.handleOnBlur() }

--- a/src/components/form/TextInput.test.js
+++ b/src/components/form/TextInput.test.js
@@ -71,14 +71,4 @@ describe('TextInput', () => {
       });
     });
   });
-
-  describe('render with theme', () => {
-    ['day', 'night'].forEach((theme) => {
-      it(theme, () => {
-        const component = getComponent({ theme });
-        const tree = component.toJSON();
-        expect(tree).toMatchSnapshot();
-      });
-    });
-  });
 });

--- a/src/components/form/__snapshots__/TextInput.test.js.snap
+++ b/src/components/form/__snapshots__/TextInput.test.js.snap
@@ -1,53 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextInput render with theme night 1`] = `
-<label
-  className="ax-input__group ax-space--x4"
->
-  <div
-    className="ax-input__button-container"
-  >
-    <div
-      className="ax-input__icon-container ax-input__icon-container--medium"
-    >
-      <input
-        className="ax-input"
-        disabled={undefined}
-        onBlur={[Function]}
-        onFocus={[Function]}
-        theme="night"
-        type="text"
-        value={undefined}
-      />
-    </div>
-  </div>
-</label>
-`;
-
-exports[`TextInput render with theme day 1`] = `
-<label
-  className="ax-input__group ax-space--x4"
->
-  <div
-    className="ax-input__button-container"
-  >
-    <div
-      className="ax-input__icon-container ax-input__icon-container--medium"
-    >
-      <input
-        className="ax-input"
-        disabled={undefined}
-        onBlur={[Function]}
-        onFocus={[Function]}
-        theme="day"
-        type="text"
-        value={undefined}
-      />
-    </div>
-  </div>
-</label>
-`;
-
 exports[`TextInput renders when disabled 1`] = `
 <label
   className="ax-input__group ax-space--x4"


### PR DESCRIPTION
##### This PR updates the <TextInput> component to make it easier to customise.

By allowing use of the props from <Base> we get a bunch of really useful axiom utilities (like textCenter) to let us customise the component in a consistent way. 