### PR TITLE
Add boundariesElement prop to Select / Popper.js

### DIFF
--- a/src/components/position/Position.js
+++ b/src/components/position/Position.js
@@ -17,6 +17,11 @@ export default class Position extends Component {
      * Children inside Position this should contain all of and
      * only PositionContent and PositionTarget!
      */
+    /** Element to use as the boundaries of the overlay */
+    boundariesElement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]),
     children: PropTypes.array.isRequired,
     /**
      * Adds control to conditionally enable or disable the positioning logic.
@@ -56,6 +61,7 @@ export default class Position extends Component {
     offset: 'middle',
     position: 'top',
     showArrow:  true,
+    boundariesElement: 'scrollParent',
   };
 
   constructor(props) {
@@ -93,7 +99,8 @@ export default class Position extends Component {
   }
 
   createPopper() {
-    const { flip, showArrow } = this.props;
+    const { boundariesElement, flip, showArrow } = this.props;
+
     const { placement } = this.state;
 
     return new popperJS(this._target, this._content, {
@@ -110,6 +117,9 @@ export default class Position extends Component {
         },
         inner: { enabled: false },
         offset: { enabled: false },
+        preventOverflow: {
+          boundariesElement,
+        },
       },
     });
   }
@@ -161,6 +171,7 @@ export default class Position extends Component {
       'offset',
       'position',
       'onPositionChange',
+      'boundariesElement',
     ]);
 
     return [

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -13,6 +13,11 @@ export default class Select extends Component {
      * Children inside Select should contain all of and
      * only SelectOption and SelectOptionGroup!
      */
+    /** Element to use as the boundaries of the select overlay */
+    boundariesElement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]),
     children: PropTypes.node,
     /** Event that is fired when the input field is cleared */
     onClear: PropTypes.func,
@@ -57,10 +62,11 @@ export default class Select extends Component {
   }
 
   render() {
-    const { children, ...props } = this.props;
+    const { boundariesElement, children, ...props } = this.props;
 
     return (
       <Dropdown
+          boundariesElement={ boundariesElement }
           enabled={ Children.count(children) > 0 }
           flip="mirror"
           position="bottom"


### PR DESCRIPTION
Adds support for `boundariesElement` to be set on the Select and Dropdown components. Eventually applies to Position so anything using Position should support `boundariesElement` too.

Comments and feedback welcome :) 