### PR TITLE
feat(BarChart) Add BarChartLabel component prop

### DIFF
--- a/src/charts/bar-chart/BarChart.js
+++ b/src/charts/bar-chart/BarChart.js
@@ -19,6 +19,8 @@ import './BarChart.css';
 
 export default class BarChart extends Component {
   static propTypes = {
+    /** The label that appears next to the bar */
+    BarChartLabelComponent: PropTypes.func,
     /**
      * Contextual component that appears when click on a dot.
      * It is provided with the `colors`, `label`, and `value` that has
@@ -93,6 +95,7 @@ export default class BarChart extends Component {
       chartKeyBenchmarkLabel,
       collapsedVisibleRowCount,
       ContextComponent,
+      BarChartLabelComponent,
       data,
       expandButtonSuffix,
       labelColumnWidth,
@@ -131,6 +134,7 @@ export default class BarChart extends Component {
               </ChartTableLabel>
               <ChartTableVisual>
                 <BarChartBars
+                    BarChartLabelComponent={ BarChartLabelComponent }
                     ContextComponent={ ContextComponent }
                     benchmark={ benchmark }
                     benchmarkHeight={ rowSpace }

--- a/src/charts/bar-chart/BarChartBars.js
+++ b/src/charts/bar-chart/BarChartBars.js
@@ -7,6 +7,7 @@ import Bars from '../bars/Bars';
 
 export default class BarChartBars extends Component {
   static propTypes = {
+    BarChartLabelComponent: PropTypes.func,
     ContextComponent: PropTypes.func,
     benchmark: PropTypes.number,
     benchmarkHeight: PropTypes.oneOf(['x1', 'x2', 'x3']),
@@ -25,6 +26,7 @@ export default class BarChartBars extends Component {
 
   render() {
     const {
+      BarChartLabelComponent,
       ContextComponent,
       benchmark,
       benchmarkHeight,
@@ -53,6 +55,7 @@ export default class BarChartBars extends Component {
 
             return (
               <BarChartContext
+                  BarChartLabelComponent={ BarChartLabelComponent }
                   ContextComponent={ ContextComponent }
                   color={ color }
                   data={ data }

--- a/src/charts/bar-chart/BarChartContext.js
+++ b/src/charts/bar-chart/BarChartContext.js
@@ -7,6 +7,7 @@ import DropdownTarget from '../../components/dropdown/DropdownTarget';
 
 export default class BarChartContext extends PureComponent {
   static propTypes = {
+    BarChartLabelComponent: PropTypes.func,
     ContextComponent: PropTypes.func,
     color: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
@@ -23,6 +24,7 @@ export default class BarChartContext extends PureComponent {
 
   render() {
     const {
+      BarChartLabelComponent,
       ContextComponent,
       color,
       data,
@@ -38,11 +40,26 @@ export default class BarChartContext extends PureComponent {
       ...rest
     } = this.props;
 
+    const getLabelComponent = () => {
+      if (!BarChartLabelComponent) {
+        return null;
+      }
+
+      return (
+        <BarChartLabelComponent
+            color={ color }
+            data={ data }
+            label={ label }
+            value={ value } />
+      );
+    };
+
     const bar = (
       <Bar { ...rest }
           color={ color }
           isFaded={ isFaded }
           isHidden={ isHidden }
+          label={ getLabelComponent() }
           labelStrong={ labelStrong }
           onMouseEnter={ onMouseEnter && (() => onMouseEnter(color)) }
           onMouseLeave={ onMouseLeave }

--- a/src/charts/bar-chart/example/index.js
+++ b/src/charts/bar-chart/example/index.js
@@ -15,6 +15,7 @@ import Paragraph from '../../../components/typography/Paragraph';
 import Small from '../../../components/typography/Small';
 import Strong from '../../../components/typography/Strong';
 import { chartKey, data } from './data';
+import Italic from '../../../components/typography/Italic';
 
 class ContextDemoComponent extends Component {
   static propTypes = {
@@ -63,6 +64,22 @@ class ContextDemoComponent extends Component {
   }
 }
 
+class BarChartDemoLabelComponent extends Component {
+  static propTypes = {
+    value: PropTypes.number.isRequired,
+  };
+
+  render() {
+    const { value } = this.props;
+
+    return (
+      <Italic>
+        {value}%
+      </Italic>
+    );
+  }
+}
+
 class BarChartExample extends Component {
   static propTypes = {
     components: PropTypes.shape({
@@ -79,6 +96,7 @@ class BarChartExample extends Component {
 
     const initialProps = {
       BarChart: {
+        BarChartLabelComponent: BarChartDemoLabelComponent,
         ContextComponent: ContextDemoComponent,
         axisTitle: '% of each something',
         chartKey,

--- a/src/charts/bars/Bar.css
+++ b/src/charts/bars/Bar.css
@@ -1,5 +1,6 @@
 .ax-bars__bar {
   display: flex;
+  position: relative;
   transition: opacity var(--transition-time-base) var(--transition-function);
 }
 
@@ -121,7 +122,7 @@
 .ax-bars--right,
 .ax-bars--left {
   & .ax-bars__bar-label {
-    flex: 0 0 var(--cmp-chart-label-width);
+    position: absolute;
   }
 }
 
@@ -148,6 +149,7 @@
 
 .ax-bars--right {
   & .ax-bars__bar-label {
+    left: 100%;
     margin-right: calc(var(--cmp-chart-label-width) * -1);
     padding-left: var(--cmp-chart-label-margin);
   }
@@ -155,6 +157,7 @@
 
 .ax-bars--left {
   & .ax-bars__bar-label {
+    right: 100%;
     margin-left: calc(var(--cmp-chart-label-width) * -1);
     padding-right: var(--cmp-chart-label-margin);
   }

--- a/src/charts/bars/Bar.js
+++ b/src/charts/bars/Bar.js
@@ -27,7 +27,7 @@ export default class Bar extends Component {
     /** When true the bar is invisible */
     isHidden: PropTypes.bool,
     /** Overwriting label above the bar instead of default percentage */
-    label: PropTypes.string,
+    label: PropTypes.node,
     /** Control for applying strong styling to the label */
     labelStrong: PropTypes.bool,
     /** Minimum thickness of the Bar */


### PR DESCRIPTION
Wouldn't it be nice to be able to pass down a component for a BarChart label rather than just a boring string? This PR adds this functionally with a new prop `BarChartLabelComponent`.

![screen shot 2018-03-01 at 10 44 35](https://user-images.githubusercontent.com/1393946/36837785-9a2410ba-1d3d-11e8-8101-130381c181ba.png)
