### PR TITLE
feat(BarChart):  Flexible labels and absolute data support

### DIFF
--- a/packages/axiom-charts/src/Bar/Bar.css
+++ b/packages/axiom-charts/src/Bar/Bar.css
@@ -1,5 +1,6 @@
 .ax-bars__bar {
   display: flex;
+  position: relative;
   transition: opacity var(--transition-time-base) var(--transition-function);
 }
 
@@ -121,7 +122,23 @@
 .ax-bars--right,
 .ax-bars--left {
   & .ax-bars__bar-label {
-    flex: 0 0 var(--cmp-chart-label-width);
+    position: absolute;
+  }
+}
+
+.ax-bars--right {
+  & .ax-bars__bar-label {
+    left: 100%;
+    margin-right: calc(var(--cmp-chart-label-width) * -1);
+    padding-left: var(--cmp-chart-label-margin);
+  }
+}
+
+.ax-bars--left {
+  & .ax-bars__bar-label {
+    right: 100%;
+    margin-left: calc(var(--cmp-chart-label-width) * -1);
+    padding-right: var(--cmp-chart-label-margin);
   }
 }
 
@@ -143,19 +160,5 @@
   & .ax-bars__bar-label {
     margin-bottom: calc(var(--cmp-chart-label-height) * -1);
     padding-top: var(--cmp-chart-label-margin);
-  }
-}
-
-.ax-bars--right {
-  & .ax-bars__bar-label {
-    margin-right: calc(var(--cmp-chart-label-width) * -1);
-    padding-left: var(--cmp-chart-label-margin);
-  }
-}
-
-.ax-bars--left {
-  & .ax-bars__bar-label {
-    margin-left: calc(var(--cmp-chart-label-width) * -1);
-    padding-right: var(--cmp-chart-label-margin);
   }
 }

--- a/packages/axiom-charts/src/Bar/Bar.js
+++ b/packages/axiom-charts/src/Bar/Bar.js
@@ -26,7 +26,7 @@ export default class Bar extends Component {
     /** When true the bar is invisible */
     isHidden: PropTypes.bool,
     /** Overwriting label above the bar instead of default percentage */
-    label: PropTypes.string,
+    label: PropTypes.node,
     /** Control for applying strong styling to the label */
     labelStrong: PropTypes.bool,
     /** Minimum thickness of the Bar */

--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -26,6 +26,8 @@ export default class BarChart extends Component {
     DropdownContext: PropTypes.func,
     /** The title that appears along the xAxis */
     axisTitle: PropTypes.string,
+    /** Control the appearance of the bar label */
+    barLabel: PropTypes.func,
     /**
      * The key that is shown along the bottom of the axis. It is also used
      * to determine the order of stacked dots.
@@ -96,6 +98,7 @@ export default class BarChart extends Component {
 
     const {
       axisTitle,
+      barLabel,
       chartKey,
       chartKeyBenchmarkLabel,
       collapsedVisibleRowCount,
@@ -145,6 +148,7 @@ export default class BarChart extends Component {
               <ChartTableVisual>
                 <BarChartBars
                     DropdownContext={ DropdownContext }
+                    barLabel={ barLabel }
                     benchmark={ benchmark }
                     benchmarkHeight={ rowSpace }
                     data={ data[index] }

--- a/packages/axiom-charts/src/BarChart/BarChartBars.js
+++ b/packages/axiom-charts/src/BarChart/BarChartBars.js
@@ -16,10 +16,12 @@ export default class BarChartBars extends Component {
     hoverColor: PropTypes.string,
     isHovered: PropTypes.bool.isRequired,
     label: PropTypes.node.isRequired,
+    lower: PropTypes.number,
     onMouseEnter: PropTypes.func.isRequired,
     onMouseLeave: PropTypes.func.isRequired,
     showBarLabel: PropTypes.bool,
     size: PropTypes.string,
+    upper: PropTypes.number,
     values: PropTypes.array.isRequired,
   };
 
@@ -34,8 +36,10 @@ export default class BarChartBars extends Component {
       hoverColor,
       isHovered,
       label,
+      lower,
       showBarLabel,
       size,
+      upper,
       values,
       onMouseEnter,
       onMouseLeave,
@@ -44,6 +48,11 @@ export default class BarChartBars extends Component {
     const classes = classnames('ax-bar-chart__bars', {
       [`ax-bar-chart__bars--${benchmarkHeight}`]: benchmarkHeight,
     });
+
+    let benchmarkValue;
+    if (benchmark) {
+      benchmarkValue = ((benchmark - lower) / (upper - lower)) * 100;
+    }
 
     return (
       <div className={ classes }>
@@ -61,10 +70,12 @@ export default class BarChartBars extends Component {
                   key={ color }
                   label={ label }
                   labelStrong={ isHovered }
+                  lower={ lower }
                   onMouseEnter={ onMouseEnter }
                   onMouseLeave={ onMouseLeave }
                   showBarLabel={ showBarLabel || color === hoverColor }
                   size={ size }
+                  upper={ upper }
                   value={ value } />
             );
           }) }
@@ -72,7 +83,7 @@ export default class BarChartBars extends Component {
 
         { benchmark !== undefined && (
           <div className="ax-bar-chart__benchmark-line-container">
-            <BarChartBenchmarkLine faded={ fadeBenchmarkLine } value={ benchmark } />
+            <BarChartBenchmarkLine faded={ fadeBenchmarkLine } value={ benchmarkValue } />
           </div>
         ) }
       </div>

--- a/packages/axiom-charts/src/BarChart/BarChartBars.js
+++ b/packages/axiom-charts/src/BarChart/BarChartBars.js
@@ -8,6 +8,7 @@ import BarChartContext from './BarChartContext';
 export default class BarChartBars extends Component {
   static propTypes = {
     DropdownContext: PropTypes.func,
+    barLabel: PropTypes.func,
     benchmark: PropTypes.number,
     benchmarkHeight: PropTypes.oneOf(['x1', 'x2', 'x3']),
     data: PropTypes.object.isRequired,
@@ -28,6 +29,7 @@ export default class BarChartBars extends Component {
   render() {
     const {
       DropdownContext,
+      barLabel,
       benchmark,
       benchmarkHeight,
       data,
@@ -63,6 +65,7 @@ export default class BarChartBars extends Component {
             return (
               <BarChartContext
                   DropdownContext={ DropdownContext }
+                  barLabel={ barLabel }
                   color={ color }
                   data={ data }
                   isFaded={ isFaded }

--- a/packages/axiom-charts/src/BarChart/BarChartContext.js
+++ b/packages/axiom-charts/src/BarChart/BarChartContext.js
@@ -12,10 +12,12 @@ export default class BarChartContext extends PureComponent {
     isHidden: PropTypes.bool,
     label: PropTypes.node.isRequired,
     labelStrong: PropTypes.bool.isRequired,
+    lower: PropTypes.number,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     showBarLabel: PropTypes.bool.isRequired,
     size: PropTypes.string,
+    upper: PropTypes.number,
     value: PropTypes.number.isRequired,
   };
 
@@ -28,23 +30,28 @@ export default class BarChartContext extends PureComponent {
       isHidden,
       label,
       labelStrong,
+      lower,
       onMouseEnter,
       onMouseLeave,
       showBarLabel,
       size,
+      upper,
       value,
       ...rest
     } = this.props;
+
+    const dValue = ((value - lower) / (upper - lower)) * 100;
 
     const bar = (
       <Bar { ...rest }
           color={ color }
           isFaded={ isFaded }
           isHidden={ isHidden }
+          label={ `${value}` }
           labelStrong={ labelStrong }
           onMouseEnter={ onMouseEnter && (() => onMouseEnter(color)) }
           onMouseLeave={ onMouseLeave }
-          percent={ value }
+          percent={ dValue }
           showLabel={ showBarLabel }
           size={ size } />
     );

--- a/packages/axiom-charts/src/BarChart/BarChartContext.js
+++ b/packages/axiom-charts/src/BarChart/BarChartContext.js
@@ -6,6 +6,7 @@ import Bar from '../Bar/Bar';
 export default class BarChartContext extends PureComponent {
   static propTypes = {
     DropdownContext: PropTypes.func,
+    barLabel: PropTypes.func,
     color: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
     isFaded: PropTypes.bool,
@@ -24,6 +25,7 @@ export default class BarChartContext extends PureComponent {
   render() {
     const {
       DropdownContext,
+      barLabel,
       color,
       data,
       isFaded,
@@ -42,12 +44,20 @@ export default class BarChartContext extends PureComponent {
 
     const dValue = ((value - lower) / (upper - lower)) * 100;
 
+    const getLabel = () => {
+      if (!barLabel) {
+        return value;
+      }
+
+      return barLabel({ value, data, color, label });
+    };
+
     const bar = (
       <Bar { ...rest }
           color={ color }
           isFaded={ isFaded }
           isHidden={ isHidden }
-          label={ `${value}` }
+          label={ getLabel() }
           labelStrong={ labelStrong }
           onMouseEnter={ onMouseEnter && (() => onMouseEnter(color)) }
           onMouseLeave={ onMouseLeave }

--- a/packages/axiom-charts/src/BarChart/__snapshots__/utils.test.js.snap
+++ b/packages/axiom-charts/src/BarChart/__snapshots__/utils.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BarChart (utils) it gets a flatt list of all values 1`] = `
+Array [
+  100,
+  0,
+  90,
+  50,
+  33,
+  40,
+  53,
+  40,
+  33,
+  50,
+  50,
+  50,
+  33,
+  69,
+  33,
+  25,
+  50,
+]
+`;

--- a/packages/axiom-charts/src/BarChart/utils.js
+++ b/packages/axiom-charts/src/BarChart/utils.js
@@ -10,20 +10,13 @@ export const formatData = (key, data) => {
   }));
 };
 
-export const getHighestValue = (data) => {
-  let max = 0;
-
-  for (let i = 0; i < data.length; i++) {
-    if (data[i].benchmark !== undefined && data[i].benchmark > max) {
-      max = data[i].benchmark;
+export const flattenValues = (data) => {
+  return data.reduce((memo, { benchmark, values }) => {
+    if (benchmark) {
+      memo.push(benchmark);
     }
 
-    for (const color in data[i].values) {
-      if (data[i].values[color] > max) {
-        max = data[i].values[color];
-      }
-    }
-  }
-
-  return max;
+    memo = memo.concat(...Object.values(values));
+    return memo;
+  }, []);
 };

--- a/packages/axiom-charts/src/BarChart/utils.test.js
+++ b/packages/axiom-charts/src/BarChart/utils.test.js
@@ -1,4 +1,4 @@
-import { formatData, getHighestValue } from './utils';
+import { formatData, flattenValues } from './utils';
 
 const chartKey = [
   { color: 'giant-leap', label: 'Brand A' },
@@ -106,7 +106,7 @@ describe('BarChart (utils)', () => {
     }]);
   });
 
-  it('it gets highest value', () => {
-    expect(getHighestValue(data)).toBe(100);
+  it('it gets a flatt list of all values', () => {
+    expect(flattenValues(data)).toMatchSnapshot();
   });
 });

--- a/packages/axiom-charts/src/ChartTable/ChartTableRows.js
+++ b/packages/axiom-charts/src/ChartTable/ChartTableRows.js
@@ -10,14 +10,13 @@ export default class ChartTableRows extends Component {
     expandButtonSuffix: PropTypes.string,
     labelColumnWidth: PropTypes.string.isRequired,
     space: PropTypes.oneOf(['x1', 'x2', 'x3']),
-    xAxisLabels: PropTypes.arrayOf(PropTypes.string),
+    xAxisLabels: PropTypes.arrayOf(PropTypes.string).isRequired,
     zoomTo: PropTypes.number,
   };
 
   static defaultProps = {
     expandButtonSuffix: 'Items',
     space: 'x2',
-    xAxisLabels: [ '0%', '10%', '20%', '30%', '40%', '50%', '60%', '70%', '80%', '90%', '100%'],
     zoomTo: 100,
   };
 

--- a/packages/axiom-charts/src/ChartTable/ChartTableRows.test.js
+++ b/packages/axiom-charts/src/ChartTable/ChartTableRows.test.js
@@ -3,14 +3,20 @@ import renderer from 'react-test-renderer';
 import ChartTableRow from './ChartTableRow';
 import ChartTableRows from './ChartTableRows';
 
-const getComponent = (props = {}) =>
-  renderer.create(
-    <ChartTableRows { ...props } labelColumnWidth="11rem">
+const getComponent = (props = {}) => {
+  const defaults = {
+    labelColumnWidth: '11rem',
+    xAxisLabels: [ '0%', '10%', '20%', '30%', '40%', '50%', '60%', '70%', '80%', '90%', '100%'],
+  };
+
+  return renderer.create(
+    <ChartTableRows { ...Object.assign({}, defaults, props) } >
       <ChartTableRow>Lorem</ChartTableRow>
       <ChartTableRow>Lorem</ChartTableRow>
       <ChartTableRow>Lorem</ChartTableRow>
     </ChartTableRows>
   );
+};
 
 describe('ChartTableRows', () => {
   it('renders with defaultProps', () => {

--- a/packages/axiom-charts/src/DotPlotChart/DotPlot.js
+++ b/packages/axiom-charts/src/DotPlotChart/DotPlot.js
@@ -32,12 +32,14 @@ export default class DotPlot extends Component {
       value: PropTypes.number.isRequired,
     })).isRequired,
     label: PropTypes.string,
+    lower: PropTypes.number,
     mouseOverColors: PropTypes.arrayOf(PropTypes.string),
     mouseOverRowIndex: PropTypes.number,
     onDotMouseEnter: PropTypes.func.isRequired,
     onDotMouseLeave: PropTypes.func.isRequired,
     rawData: PropTypes.object.isRequired,
     rowIndex: PropTypes.number.isRequired,
+    upper: PropTypes.number,
   };
 
   render() {
@@ -46,18 +48,25 @@ export default class DotPlot extends Component {
       benchmark,
       data,
       label,
+      lower,
       mouseOverColors,
       mouseOverRowIndex,
       onDotMouseEnter,
       onDotMouseLeave,
       rawData,
       rowIndex,
+      upper,
       ...rest
     } = this.props;
 
+    let benchmarkValue;
+    if (benchmark) {
+      benchmarkValue = ((benchmark - lower) / (upper - lower)) * 100;
+    }
+
     return (
       <Base { ...rest } className="ax-dot-plot">
-        { getLines(data, benchmark, mouseOverRowIndex, mouseOverColors, rowIndex)
+        { getLines(data, benchmark, mouseOverRowIndex, mouseOverColors, rowIndex, lower, upper)
           .map(({ fromBenchmark, toBenchmark, faded, fromX, toX }) =>
             <div
                 className={ differenceLineContainerClasses(fromBenchmark, toBenchmark) }
@@ -76,16 +85,18 @@ export default class DotPlot extends Component {
               hidden={ isDotHidden(mouseOverRowIndex, mouseOverColors, rowIndex, colors) }
               key={ value }
               label={ label }
+              lower={ lower }
               onMouseEnter={ () => onDotMouseEnter(colors) }
               onMouseLeave={ onDotMouseLeave }
+              upper={ upper }
               value={ value } />
         ) }
 
-        { benchmark !== undefined && (
+        { benchmarkValue !== undefined && (
           <div className="ax-dot-plot__benchmark-line-container">
             <DotPlotBenchmarkLine
                 faded={ isBenchmarkFaded(mouseOverRowIndex, mouseOverColors, rowIndex) }
-                value={ benchmark } />
+                value={ benchmarkValue } />
           </div>
         ) }
 
@@ -94,7 +105,8 @@ export default class DotPlot extends Component {
               hidden={ isValueHidden(mouseOverRowIndex, mouseOverColors, rowIndex, colors) }
               key={ value }
               textStrong={ isValueStrong(mouseOverRowIndex, mouseOverColors, rowIndex, colors) }
-              value={ value } />
+              value={ value }
+              x={ ((value - lower) / (upper - lower)) * 100 } />
         ) }
       </Base>
     );

--- a/packages/axiom-charts/src/DotPlotChart/DotPlot.js
+++ b/packages/axiom-charts/src/DotPlotChart/DotPlot.js
@@ -31,6 +31,7 @@ export default class DotPlot extends Component {
       colors: PropTypes.arrayOf(PropTypes.string).isRequired,
       value: PropTypes.number.isRequired,
     })).isRequired,
+    dotPlotLabel: PropTypes.func,
     label: PropTypes.string,
     lower: PropTypes.number,
     mouseOverColors: PropTypes.arrayOf(PropTypes.string),
@@ -47,6 +48,7 @@ export default class DotPlot extends Component {
       DropdownContext,
       benchmark,
       data,
+      dotPlotLabel,
       label,
       lower,
       mouseOverColors,
@@ -102,6 +104,7 @@ export default class DotPlot extends Component {
 
         { data.map(({ colors, value }) =>
           <DotPlotValue
+              dotPlotLabel={ dotPlotLabel }
               hidden={ isValueHidden(mouseOverRowIndex, mouseOverColors, rowIndex, colors) }
               key={ value }
               textStrong={ isValueStrong(mouseOverRowIndex, mouseOverColors, rowIndex, colors) }

--- a/packages/axiom-charts/src/DotPlotChart/DotPlotChart.js
+++ b/packages/axiom-charts/src/DotPlotChart/DotPlotChart.js
@@ -49,6 +49,8 @@ export default class DotPlotChart extends Component {
       label: PropTypes.node.isRequired,
       values: PropTypes.object.isRequired,
     })).isRequired,
+    /** Control the appearance of the value */
+    dotPlotLabel: PropTypes.func,
     /** The description given to the expand button */
     expandButtonSuffix: PropTypes.string,
     /** The width of the yAxis labels columns */
@@ -111,6 +113,7 @@ export default class DotPlotChart extends Component {
       collapsedVisibleRowCount,
       DropdownContext,
       data,
+      dotPlotLabel,
       expandButtonSuffix,
       labelColumnWidth,
       lower = dataLower,
@@ -151,6 +154,7 @@ export default class DotPlotChart extends Component {
                     DropdownContext={ DropdownContext }
                     benchmark={ benchmark }
                     data={ values }
+                    dotPlotLabel={ dotPlotLabel }
                     label={ label }
                     lower={ finalLower }
                     mouseOverColors={ mouseOverColors }

--- a/packages/axiom-charts/src/DotPlotChart/DotPlotContext.js
+++ b/packages/axiom-charts/src/DotPlotChart/DotPlotContext.js
@@ -9,6 +9,8 @@ export default class DotPlotContext extends Component {
     colors: PropTypes.arrayOf(PropTypes.string).isRequired,
     data: PropTypes.object.isRequired,
     label: PropTypes.string.isRequired,
+    lower: PropTypes.number,
+    upper: PropTypes.number,
     value: PropTypes.number.isRequired,
   };
 
@@ -18,9 +20,13 @@ export default class DotPlotContext extends Component {
       colors,
       data,
       label,
+      lower,
+      upper,
       value,
       ...rest
     } = this.props;
+
+    const dValue = ((value - lower) / (upper - lower)) * 100;
 
     if (DropdownContext) {
       return (
@@ -28,7 +34,7 @@ export default class DotPlotContext extends Component {
           <DropdownTarget>
             <DotPlotDots { ...rest }
                 colors={ colors }
-                value={ value } />
+                value={ dValue } />
           </DropdownTarget>
 
           <DropdownSource>
@@ -45,7 +51,7 @@ export default class DotPlotContext extends Component {
     return (
       <DotPlotDots { ...rest }
           colors={ colors }
-          value={ value } />
+          value={ dValue } />
     );
   }
 }

--- a/packages/axiom-charts/src/DotPlotChart/DotPlotValue.js
+++ b/packages/axiom-charts/src/DotPlotChart/DotPlotValue.js
@@ -7,10 +7,11 @@ export default class DotPlotValue extends Component {
   static propTypes = {
     hidden: PropTypes.bool,
     value: PropTypes.number.isRequired,
+    x: PropTypes.number.isRequired,
   };
 
   render() {
-    const { hidden, value, ...rest } = this.props;
+    const { hidden, value, x, ...rest } = this.props;
     const classes = classnames('ax-dot-plot__value', {
       'ax-dot-plot__value--hidden': hidden,
     });
@@ -18,7 +19,7 @@ export default class DotPlotValue extends Component {
     return (
       <Base { ...rest }
           className={ classes }
-          style={ { left: `${value}%` } }>
+          style={ { left: `${x}%` } }>
         <Small>{ value }%</Small>
       </Base>
     );

--- a/packages/axiom-charts/src/DotPlotChart/DotPlotValue.js
+++ b/packages/axiom-charts/src/DotPlotChart/DotPlotValue.js
@@ -5,22 +5,31 @@ import { Base, Small } from '@brandwatch/axiom-components';
 
 export default class DotPlotValue extends Component {
   static propTypes = {
+    dotPlotLabel: PropTypes.func,
     hidden: PropTypes.bool,
     value: PropTypes.number.isRequired,
     x: PropTypes.number.isRequired,
   };
 
   render() {
-    const { hidden, value, x, ...rest } = this.props;
+    const { hidden, value, dotPlotLabel, x, ...rest } = this.props;
     const classes = classnames('ax-dot-plot__value', {
       'ax-dot-plot__value--hidden': hidden,
     });
+
+    const getLabel = () => {
+      if (dotPlotLabel) {
+        return dotPlotLabel({ value });
+      }
+
+      return value;
+    };
 
     return (
       <Base { ...rest }
           className={ classes }
           style={ { left: `${x}%` } }>
-        <Small>{ value }%</Small>
+        <Small>{ getLabel() }</Small>
       </Base>
     );
   }

--- a/packages/axiom-charts/src/DotPlotChart/__snapshots__/utils.test.js.snap
+++ b/packages/axiom-charts/src/DotPlotChart/__snapshots__/utils.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DotPlot (utils) it gets a flatt list of all values 1`] = `
+Array [
+  100,
+  0,
+  90,
+  50,
+  33,
+  40,
+  53,
+  40,
+  33,
+  50,
+  50,
+  50,
+  33,
+  69,
+  33,
+  25,
+  50,
+]
+`;

--- a/packages/axiom-charts/src/DotPlotChart/utils.js
+++ b/packages/axiom-charts/src/DotPlotChart/utils.js
@@ -22,25 +22,18 @@ export const formatData = (key, data) => {
   }));
 };
 
-export const getHighestValue = (data) => {
-  let max = 0;
-
-  for (let i = 0; i < data.length; i++) {
-    if (data[i].benchmark !== undefined && data[i].benchmark > max) {
-      max = data[i].benchmark;
+export const flattenValues = (data) => {
+  return data.reduce((memo, { benchmark, values }) => {
+    if (benchmark) {
+      memo.push(benchmark);
     }
 
-    for (const color in data[i].values) {
-      if (data[i].values[color] > max) {
-        max = data[i].values[color];
-      }
-    }
-  }
-
-  return max;
+    memo = memo.concat(...Object.values(values));
+    return memo;
+  }, []);
 };
 
-export const getLines = (data, benchmark, mouseOverRowIndex, mouseOverColors, rowIndex) => {
+export const getLines = (data, benchmark, mouseOverRowIndex, mouseOverColors, rowIndex, lower, upper) => {
   const lines = [];
   const elements = data
     .filter(({ colors }) => mouseOverRowIndex === rowIndex ||
@@ -57,8 +50,8 @@ export const getLines = (data, benchmark, mouseOverRowIndex, mouseOverColors, ro
       fromBenchmark: elements[i].colors.length === 0,
       toBenchmark: elements[i + 1] && elements[i + 1].colors.length === 0,
       faded: isLineFaded(mouseOverRowIndex),
-      fromX: elements[i].value,
-      toX: elements[i + 1].value,
+      fromX: ((elements[i].value - lower) / (upper - lower)) * 100,
+      toX: ((elements[i + 1].value - lower) / (upper - lower)) * 100,
     });
   }
 

--- a/packages/axiom-charts/src/DotPlotChart/utils.test.js
+++ b/packages/axiom-charts/src/DotPlotChart/utils.test.js
@@ -1,7 +1,7 @@
 import {
   formatData,
   getDotColors,
-  getHighestValue,
+  flattenValues,
   getLines,
   isDotFaded,
   isDotHidden,
@@ -107,8 +107,8 @@ describe('DotPlot (utils)', () => {
     }]);
   });
 
-  it('it gets highest value', () => {
-    expect(getHighestValue(data)).toBe(100);
+  it('it gets a flatt list of all values', () => {
+    expect(flattenValues(data)).toMatchSnapshot();
   });
 
   describe('with no mouse over', () => {
@@ -185,7 +185,7 @@ describe('DotPlot (utils)', () => {
             { colors: ['red'], value: 10 },
             { colors: ['terra-form'], value: 20 },
             { colors: ['giant-leap'], value: 30 },
-          ], 33, 1, ['red'], 2)).toEqual([{
+          ], 33, 1, ['red'], 2, 0, 100)).toEqual([{
             fromBenchmark: false,
             toBenchmark: true,
             faded: true,
@@ -240,7 +240,7 @@ describe('DotPlot (utils)', () => {
           expect(getLines([
             { colors: ['red'], value: 10 },
             { colors: ['terra-form', 'giant-leap'], value: 20 },
-          ], 33, 1, ['terra-form', 'giant-leap'], 2)).toEqual([{
+          ], 33, 1, ['terra-form', 'giant-leap'], 2, 0, 100)).toEqual([{
             fromBenchmark: false,
             toBenchmark: true,
             faded: true,
@@ -265,7 +265,7 @@ describe('DotPlot (utils)', () => {
           expect(getLines([
             { colors: ['red'], value: 10 },
             { colors: ['terra-form', 'giant-leap'], value: 20 },
-          ], 33, 1, ['terra-form', 'giant-leap'], 1)).toEqual([{
+          ], 33, 1, ['terra-form', 'giant-leap'], 1, 0, 100)).toEqual([{
             fromBenchmark: false,
             toBenchmark: false,
             faded: true,

--- a/site/components/Documentation/Resources/Charts/BarChart.js
+++ b/site/components/Documentation/Resources/Charts/BarChart.js
@@ -21,7 +21,9 @@ export default class Documentation extends Component {
               collapsedVisibleRowCount={ 4 }
               data={ dotPlotData }
               expandButtonSuffix="Categories"
-              labelColumnWidth="11rem" />
+              labelColumnWidth="11rem"
+              lower={ 0 }
+              upper={ 100 } />
         </DocumentationShowCase>
 
         <DocumentationApi components={ [

--- a/site/components/Documentation/Resources/Charts/BarChart.js
+++ b/site/components/Documentation/Resources/Charts/BarChart.js
@@ -23,6 +23,7 @@ export default class Documentation extends Component {
               expandButtonSuffix="Categories"
               labelColumnWidth="11rem"
               lower={ 0 }
+              showBarLabel={ true }
               upper={ 100 } />
         </DocumentationShowCase>
 

--- a/site/components/Documentation/Resources/Charts/BarChart.js
+++ b/site/components/Documentation/Resources/Charts/BarChart.js
@@ -24,7 +24,8 @@ export default class Documentation extends Component {
               labelColumnWidth="11rem"
               lower={ 0 }
               showBarLabel={ true }
-              upper={ 100 } />
+              upper={ 100 }
+              xAxisLabels={ [ '0', '10', '20', '30', '40', '50', '60', '70', '80', '90', '100'] }/>
         </DocumentationShowCase>
 
         <DocumentationApi components={ [

--- a/site/components/Documentation/Resources/Charts/Chart.js
+++ b/site/components/Documentation/Resources/Charts/Chart.js
@@ -87,7 +87,8 @@ export default class Documentation extends Component {
                   collapsedVisibleRowCount={ 6 }
                   data={ dotPlotData }
                   expandButtonSuffix="Categories"
-                  labelColumnWidth="11rem" />
+                  labelColumnWidth="11rem"
+                  xAxisLabels={ [ '0', '10', '20', '30', '40', '50', '60', '70', '80', '90', '100'] }/>
             </ChartBody>
           </Chart>
         </DocumentationShowCase>

--- a/site/components/Documentation/Resources/Charts/DotPlotChart.js
+++ b/site/components/Documentation/Resources/Charts/DotPlotChart.js
@@ -22,7 +22,9 @@ export default class Documentation extends Component {
               collapsedVisibleRowCount={ 6 }
               data={ dotPlotData }
               expandButtonSuffix="Categories"
-              labelColumnWidth="11rem" />
+              labelColumnWidth="11rem"
+              lower={ 0 }
+              upper={ 100 } />
         </DocumentationShowCase>
 
         <DocumentationApi components={ [

--- a/site/components/Documentation/Resources/Charts/DotPlotChart.js
+++ b/site/components/Documentation/Resources/Charts/DotPlotChart.js
@@ -24,7 +24,8 @@ export default class Documentation extends Component {
               expandButtonSuffix="Categories"
               labelColumnWidth="11rem"
               lower={ 0 }
-              upper={ 100 } />
+              upper={ 100 }
+              xAxisLabels={ [ '0', '10', '20', '30', '40', '50', '60', '70', '80', '90', '100'] }/>
         </DocumentationShowCase>
 
         <DocumentationApi components={ [


### PR DESCRIPTION
This PR makes the BarChart component even more appealing with a few changes.

<img width="739" alt="screen shot 2018-03-05 at 16 26 39" src="https://user-images.githubusercontent.com/1393946/36983303-52a730d4-2092-11e8-85c2-45e66be8e681.png">


### Custom range

Before the BarChart was limited to values between 0% and 100%. With the new properties `lower` and `upper` you can specify the range like you want. If you don't any of these values, the component will automatically take the lowest and highest value from the passed data.

### Tweak bar label

Sometimes you want to show more than just a boring number in your BarChart. With the new property `barLabel` you can easily append units like a percentage sign or return a rich component and go wild.


## Breaking changes

I'm sorry, this PR contains a few breaking changes:

1. To retain the previous behaviour of the `BarChart` and `DotPlotChart` with values going from 0 up to 100, you have to pass `lower=0` and `upper=100` to not let the new behaviour kick-in. Otherwise your Chart will start from the lowest value up to the highest value.

2. In favour of the custom range, the `BarChart` and `DotPlotChart` does not add a percentage sign anymore. Use the `barLabel` or `dotPlotLabel` property to suffix your values: `barLabelFormatter={ value => `${value}%` }`

3. Also in the context of the custom range, we had to mark `xAxisLabels` as required.

4. The new custom bar labels required to change the positing of the labels. Before Flexbox was used to position the labels at the end of the bar chart. This was conflicting with the new behaviour. 

@HHogg Since this is my first feature PR to Axiom, please don't hesitate to spam my inbox 😉 

