### PR TITLE
feat: adds an axis utils

### DIFF
--- a/packages/axiom-charts/src/index.js
+++ b/packages/axiom-charts/src/index.js
@@ -20,3 +20,4 @@ export { default as MirroredColumnChart } from './ColumnChart/MirroredColumnChar
 export { default as SparkLine } from './SparkLine/SparkLine';
 export { default as Word } from './WordCloud/Word';
 export { default as WordCloud } from './WordCloud/WordCloud';
+export { default as axisUtils } from './utils/axisUtils';

--- a/packages/axiom-charts/src/utils/__snapshots__/axisUtils.test.js.snap
+++ b/packages/axiom-charts/src/utils/__snapshots__/axisUtils.test.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getEquallyDistributedAxisLabels creates equal labels when lower -1, upper 1, tickCount 7 1`] = `
+Array [
+  -1,
+  -0.6666666666666667,
+  -0.33333333333333337,
+  0,
+  0.33333333333333326,
+  0.6666666666666665,
+  1,
+]
+`;
+
+exports[`getEquallyDistributedAxisLabels creates equal labels when lower -10k, upper 10k, tickCount 11 1`] = `
+Array [
+  -10000,
+  -8000,
+  -6000,
+  -4000,
+  -2000,
+  0,
+  2000,
+  4000,
+  6000,
+  8000,
+  10000,
+]
+`;
+
+exports[`getEquallyDistributedAxisLabels creates equal labels when lower 0, upper 1, tickCount 11 1`] = `
+Array [
+  0,
+  0.1,
+  0.2,
+  0.30000000000000004,
+  0.4,
+  0.5,
+  0.6000000000000001,
+  0.7000000000000001,
+  0.8,
+  0.9,
+  1,
+]
+`;
+
+exports[`getEquallyDistributedAxisLabels creates equal labels when lower 0, upper 10k, tickCount 6 1`] = `
+Array [
+  0,
+  2000,
+  4000,
+  6000,
+  8000,
+  10000,
+]
+`;
+
+exports[`getEquallyDistributedAxisLabels creates equal labels when lower 1k, upper 10k, tickCount 6 1`] = `
+Array [
+  1000,
+  2800,
+  4600,
+  6400,
+  8200,
+  10000,
+]
+`;
+
+exports[`getEquallyDistributedAxisLabels creates equal labels when lower 70k, upper 1m, tickCount 6 1`] = `
+Array [
+  70000,
+  256000,
+  442000,
+  628000,
+  814000,
+  1000000,
+]
+`;
+
+exports[`getEquallyDistributedAxisLabels formats label when "labelFormatter" is provided 1`] = `
+Array [
+  "formatted 1000 unit",
+  "formatted 2800 unit",
+  "formatted 4600 unit",
+  "formatted 6400 unit",
+  "formatted 8200 unit",
+  "formatted 10000 unit",
+]
+`;
+
+exports[`getEquallyDistributedAxisLabels provides a minimum of 3 ticks if less is specified 1`] = `
+Array [
+  0,
+  5000,
+  10000,
+]
+`;

--- a/packages/axiom-charts/src/utils/axisUtils.js
+++ b/packages/axiom-charts/src/utils/axisUtils.js
@@ -1,0 +1,37 @@
+const DEFAULT_TICK_COUNT = 5;
+const MIN_TICK_COUNT = 3;
+
+export function getEquallyDistributedAxisLabels({
+    lower,
+    upper,
+    tickCount = DEFAULT_TICK_COUNT,
+    labelFormatter = v => v,
+}) {
+  const finalTickCount = Math.max(MIN_TICK_COUNT, tickCount);
+  const tickSize = (upper - lower) / (finalTickCount - 1);
+  const ticks = [];
+
+  for (let index = 0; index < finalTickCount; index++) {
+    ticks.push(index * tickSize + lower);
+  }
+
+  return ticks.map(labelFormatter);
+}
+
+function getOrder(value) {
+  if (value === 0) {
+    return 0;
+  }
+
+  return Math.ceil(Math.log10(value));
+}
+
+export function getAxisUpper(values) {
+  const max = Math.max.apply(null, values);
+  return Math.pow(10, getOrder(max));
+}
+
+export default {
+  getEquallyDistributedAxisLabels,
+  getAxisUpper,
+};

--- a/packages/axiom-charts/src/utils/axisUtils.test.js
+++ b/packages/axiom-charts/src/utils/axisUtils.test.js
@@ -1,0 +1,126 @@
+import { getEquallyDistributedAxisLabels, getAxisUpper } from './axisUtils';
+
+describe('getEquallyDistributedAxisLabels', () => {
+  it('defaults to 5 ticks', () => {
+    const xAxisLabels = getEquallyDistributedAxisLabels({
+      lower: 0,
+      upper: 10000,
+    });
+    expect(xAxisLabels.length).toEqual(5);
+  });
+
+  it('provides a minimum of 3 ticks if less is specified', () => {
+    const xAxisLabels = getEquallyDistributedAxisLabels({
+      lower: 0,
+      upper: 10000,
+      tickCount: 2,
+    });
+    expect(xAxisLabels).toMatchSnapshot();
+  });
+
+  it('creates equal labels when lower 0, upper 10k, tickCount 6', () => {
+    const xAxisLabels = getEquallyDistributedAxisLabels({
+      lower: 0,
+      upper: 10000,
+      tickCount: 6,
+    });
+    expect(xAxisLabels).toMatchSnapshot();
+  });
+
+  it('creates equal labels when lower 1k, upper 10k, tickCount 6', () => {
+    const xAxisLabels = getEquallyDistributedAxisLabels({
+      lower: 1000,
+      upper: 10000,
+      tickCount: 6,
+    });
+    expect(xAxisLabels).toMatchSnapshot();
+  });
+
+  it('creates equal labels when lower 70k, upper 1m, tickCount 6', () => {
+    const xAxisLabels = getEquallyDistributedAxisLabels({
+      lower: 70000,
+      upper: 1000000,
+      tickCount: 6,
+    });
+    expect(xAxisLabels).toMatchSnapshot();
+  });
+
+  it('creates equal labels when lower -10k, upper 10k, tickCount 11', () => {
+    const xAxisLabels = getEquallyDistributedAxisLabels({
+      lower: -10000,
+      upper: 10000,
+      tickCount: 11,
+    });
+    expect(xAxisLabels).toMatchSnapshot();
+  });
+
+  it('creates equal labels when lower 0, upper 1, tickCount 11', () => {
+    const xAxisLabels = getEquallyDistributedAxisLabels({
+      lower: 0,
+      upper: 1,
+      tickCount: 11,
+    });
+    expect(xAxisLabels).toMatchSnapshot();
+  });
+
+  it('creates equal labels when lower -1, upper 1, tickCount 7', () => {
+    const xAxisLabels = getEquallyDistributedAxisLabels({
+      lower: -1,
+      upper: 1,
+      tickCount: 7,
+    });
+    expect(xAxisLabels).toMatchSnapshot();
+  });
+
+  it('formats label when "labelFormatter" is provided', () => {
+    const xAxisLabels = getEquallyDistributedAxisLabels({
+      lower: 1000,
+      upper: 10000,
+      tickCount: 6,
+      labelFormatter: v => `formatted ${v} unit`,
+    });
+    expect(xAxisLabels).toMatchSnapshot();
+  });
+});
+
+describe('getAxisUpper', () => {
+  it('returns 0.1 when max is below 0.1', () => {
+    expect(getAxisUpper([0, 0.011])).toEqual(0.1);
+    expect(getAxisUpper([0, 0.05, 0.099])).toEqual(0.1);
+  });
+
+  it('returns 1 when max is below or equal 1', () => {
+    expect(getAxisUpper([0, 0.5])).toEqual(1);
+    expect(getAxisUpper([0, 0.1, 0.2, 0.9])).toEqual(1);
+    expect(getAxisUpper([0.9999999, 0.90005])).toEqual(1);
+    expect(getAxisUpper([0, 1])).toEqual(1);
+  });
+
+  it('returns 10 when max is below or equal 10', () => {
+    expect(getAxisUpper([1, 0, 9])).toEqual(10);
+    expect(getAxisUpper([10, 0, 9])).toEqual(10);
+    expect(getAxisUpper([0, 0, 10])).toEqual(10);
+  });
+
+  it('returns 100 when max is below or equal 100', () => {
+    expect(getAxisUpper([0, 1, 2, 11])).toEqual(100);
+    expect(getAxisUpper([20, 99, 50])).toEqual(100);
+    expect(getAxisUpper([20, 100])).toEqual(100);
+  });
+
+  it('returns 1000 when max is below or equal 1000', () => {
+    expect(getAxisUpper([200, 999, 100])).toEqual(1000);
+    expect(getAxisUpper([200, 201, 101])).toEqual(1000);
+    expect(getAxisUpper([200, 1000])).toEqual(1000);
+  });
+
+  it('returns 10000 when max is below 10000', () => {
+    expect(getAxisUpper([20, 40, 9999])).toEqual(10000);
+    expect(getAxisUpper([10, 20, 1001])).toEqual(10000);
+    expect(getAxisUpper([0, 0, 10000])).toEqual(10000);
+  });
+
+  it('returns 100000 when max is below 100000', () => {
+    expect(getAxisUpper([20, 0, 99999])).toEqual(100000);
+  });
+});


### PR DESCRIPTION
Now that the BarChart can display absolute values instead of just percent, I added this axis helper providing: 

* `axiUtilsgetAxisUpper([25, 41, ...])`
  Calculates an upper based on a array of values to be charted. This is still pretty dumb, as it'll always choose the next power of 10 based on the maximum value used.
* `axisUtils.getEquallyDistributedAxisLabels(upper, lower, tickCount = 5, labelFormatter)`
  Generates labels for equally distributed ticks between upper and lower.
