### PR TITLE
New UI Colours, Shadows and Shading pattern. 

### DIFF
--- a/packages/axiom-components/src/AlertDialog/AlertDialog.js
+++ b/packages/axiom-components/src/AlertDialog/AlertDialog.js
@@ -37,7 +37,7 @@ export default class AlertDialog extends Component {
     return (
       <Modal { ...rest }
           onOverlayClick={ onRequestClose }
-          withOverlay={ false }>
+          overlayShade={ null }>
         <Base className="ax-alert-dialog">
           { children }
         </Base>

--- a/packages/axiom-components/src/AlertIcon/AlertIcon.css
+++ b/packages/axiom-components/src/AlertIcon/AlertIcon.css
@@ -41,6 +41,6 @@
 }
 
 .ax-alert-icon--subtle {
-  background-color: var(--color-theme-text--disabled);
+  background-color: var(--color-theme-background--overlay-light);
   color: var(--color-ui-white-noise);
 }

--- a/packages/axiom-components/src/Card/Card.css
+++ b/packages/axiom-components/src/Card/Card.css
@@ -71,7 +71,7 @@
   left: 0;
   padding-top: var(--spacing-grid-size--x2);
   padding-bottom: var(--spacing-grid-size--x2);
-  background-color: var(--color-theme-day-text--subtle);
+  background-color: var(--color-theme-day-background--overlay-heavy);
   color: var(--color-theme-night-text);
 }
 

--- a/packages/axiom-components/src/Card/Card.css
+++ b/packages/axiom-components/src/Card/Card.css
@@ -1,3 +1,5 @@
+/* stylelint-disable no-descending-specificity */
+
 .ax-card {
   border-radius: var(--component-border-radius);
   color: var(--color-theme-text);
@@ -7,13 +9,55 @@
   transition-timing-function: var(--transition-function);
 
   @nest .ax-card-list--divided & {
-    border-bottom: 0.0625rem solid var(--color-theme-border);
+    border-bottom: 0.0625rem dotted var(--color-theme-border);
     border-radius: 0;
   }
 }
 
+.ax-card--border {
+  box-shadow: var(--drop-shadow-theme-border);
+}
+
+.ax-card--hover.ax-card--shadow,
+.ax-card--clickable:hover.ax-card--shadow {
+  box-shadow: var(--drop-shadow-theme-elevation--x2);
+}
+
+.ax-card--hover.ax-card--border.ax-card--shadow,
+.ax-card--clickable:hover.ax-card--border.ax-card--shadow {
+  box-shadow:
+    var(--drop-shadow-theme-border),
+    var(--drop-shadow-theme-elevation--x2);
+}
+
+.ax-card--shadow,
+.ax-card--active.ax-card--shadow,
+.ax-card--clickable:active.ax-card--shadow {
+  box-shadow: var(--drop-shadow-theme-elevation--x1);
+}
+
+.ax-card--border.ax-card--shadow,
+.ax-card--active.ax-card--border.ax-card--shadow,
+.ax-card--clickable:active.ax-card--border.ax-card--shadow {
+  box-shadow:
+    var(--drop-shadow-theme-border),
+    var(--drop-shadow-theme-elevation--x1);
+}
+
+.ax-card--shade-1 { background-color: var(--color-theme-background--shade-1); }
+.ax-card--shade-2 { background-color: var(--color-theme-background--shade-2); }
+.ax-card--shade-3 { background-color: var(--color-theme-background--shade-3); }
+.ax-card--shade-4 { background-color: var(--color-theme-background--shade-4); }
+
+.ax-card--clickable {
+  cursor: pointer;
+}
+
 .ax-card__content {
   position: relative;
+  transition-property: background-color;
+  transition-duration: var(--transition-time-base);
+  transition-timing-function: var(--transition-function);
 }
 
 .ax-card__content--size-small {
@@ -31,6 +75,16 @@
   padding-bottom: var(--spacing-grid-size--x6);
 }
 
+.ax-card--hover:not(.ax-card--shadow) .ax-card__content,
+.ax-card--clickable:not(.ax-card--shadow):hover .ax-card__content {
+  background-color: var(--color-theme-background--hover);
+}
+
+.ax-card--active:not(.ax-card--shadow) .ax-card__content,
+.ax-card--clickable:not(.ax-card--shadow):active .ax-card__content {
+  background-color: var(--color-theme-background--active);
+}
+
 .ax-card__content:not(:last-child)::after {
   content: '';
   position: absolute;
@@ -43,21 +97,6 @@
 
 .ax-card__content--separator-dotted::after { border-bottom-style: dotted; }
 .ax-card__content--separator-solid::after { border-bottom-style: solid; }
-
-.ax-card--color-default,
-.ax-card__content--color-default {
-  background-color: var(--color-theme-card-background);
-}
-
-.ax-card--color-dark,
-.ax-card__content--color-dark {
-  background-color: var(--color-theme-card-background--dark);
-}
-
-.ax-card--color-darker,
-.ax-card__content--color-darker {
-  background-color: var(--color-theme-card-background--darker);
-}
 
 .ax-card__image {
   position: relative;
@@ -112,60 +151,4 @@
     right: var(--spacing-grid-size--x6);
     left: var(--spacing-grid-size--x6);
   }
-}
-
-.ax-card--elevation-x1 { box-shadow: var(--drop-shadow-theme-elevation--x1); }
-.ax-card--elevation-x2 { box-shadow: var(--drop-shadow-theme-elevation--x2); }
-
-.ax-card--border {
-  &.ax-card--elevation-x0 {
-    box-shadow: var(--drop-shadow-theme-border);
-  }
-
-  &.ax-card--elevation-x1 {
-    box-shadow:
-      var(--drop-shadow-theme-border),
-      var(--drop-shadow-theme-elevation--x1);
-  }
-
-  &.ax-card--elevation-x2 {
-    box-shadow:
-      var(--drop-shadow-theme-border),
-      var(--drop-shadow-theme-elevation--x2);
-  }
-}
-
-.ax-card--clickable {
-  cursor: pointer;
-
-  &:hover,
-  &:active,
-  &.ax-card--hover {
-    transform: translateZ(0); /* New stacking context for box-shadow */
-  }
-
-  &:active {
-    box-shadow: var(--drop-shadow-theme-elevation--x1);
-
-    &.ax-card--border {
-      box-shadow:
-        var(--drop-shadow-theme-border),
-        var(--drop-shadow-theme-elevation--x1);
-    }
-  }
-
-  &.ax-card--hover:not(:active),
-  &:hover:not(:active) {
-    box-shadow: var(--drop-shadow-theme-elevation--x2);
-
-    &.ax-card--border {
-      box-shadow:
-        var(--drop-shadow-theme-border),
-        var(--drop-shadow-theme-elevation--x2);
-    }
-  }
-}
-
-.ax-card--active .ax-card__content {
-  background-color: var(--color-theme-card-background--active);
 }

--- a/packages/axiom-components/src/Card/Card.js
+++ b/packages/axiom-components/src/Card/Card.js
@@ -7,17 +7,17 @@ import './Card.css';
 const cardListStyleProps = {
   divided: {
     border: false,
-    elevation: 'x0',
+    shadow: false,
     space: 'x0',
   },
   seamless: {
     border: false,
-    elevation: 'x0',
+    shadow: false,
     space: 'x0',
   },
   separate: {
     border: true,
-    elevation: 'x1',
+    shadow: false,
     space: 'x2',
   },
 };
@@ -30,21 +30,20 @@ export default class Card extends Component {
     border: PropTypes.bool,
     /** Content to be inserted inside the Card */
     children: PropTypes.node.isRequired,
-    /** Color variation */
-    color: PropTypes.oneOf(['default', 'dark', 'darker']),
-    /** Applies styling to give the Card an elevated feel from the page */
-    elevation: PropTypes.oneOf(['x0', 'x1', 'x2']),
     /** Applies styling to indicate the Card is in an hovered state */
     hover: PropTypes.bool,
     /** When provided, applies styling to indicate the Card is clickable */
     onClick: PropTypes.func,
+    /** Shade of the background color */
+    shade: PropTypes.oneOf(['shade-1', 'shade-2', 'shade-3', 'shade-4']),
+    /** Applies a shadow to the card */
+    shadow: PropTypes.bool,
     /** Increases/decreases the size of the card */
     size: PropTypes.oneOf(['small', 'medium', 'large']),
   };
 
   static defaultProps = {
-    color: 'default',
-    elevation: 'x0',
+    shade: 'shade-1',
     size: 'medium',
   };
 
@@ -63,22 +62,22 @@ export default class Card extends Component {
       active,
       border,
       children,
-      color,
-      elevation,
       hover,
       onClick,
+      shade,
+      shadow,
       size,
       ...rest
     } = props;
 
     const classes = classnames('ax-card',
-      `ax-card--elevation-${elevation}`,
       `ax-card--size-${size}`, {
         'ax-card--active': active,
         'ax-card--border': border,
-        [`ax-card--color-${color}`]: color,
         'ax-card--clickable': onClick,
         'ax-card--hover': hover,
+        [`ax-card--${shade}`]: shade,
+        'ax-card--shadow': shadow,
       }
     );
 

--- a/packages/axiom-components/src/DataPicker/DataPicker.js
+++ b/packages/axiom-components/src/DataPicker/DataPicker.js
@@ -78,7 +78,7 @@ export default class DataPicker extends Component {
     return (
       <Card { ...rest }
           border={ Boolean(dropdownMenu) }
-          color={ dropdownMenu ? 'default' : 'darker' }
+          shade={ dropdownMenu ? 'shade-1' : 'shade-3' }
           size="medium">
         <div className="ax-data-picker">
           <div className="ax-data-picker__dropdown">

--- a/packages/axiom-components/src/DataPicker/__snapshots__/DataPicker.test.js.snap
+++ b/packages/axiom-components/src/DataPicker/__snapshots__/DataPicker.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DataPicker renders with defaultProps 1`] = `
 <div
-  className="ax-card ax-card--elevation-x0 ax-card--size-medium ax-card--border ax-card--color-default"
+  className="ax-card ax-card--size-medium ax-card--border ax-card--shade-1"
   onClick={undefined}
 >
   <div
@@ -122,7 +122,7 @@ exports[`DataPicker renders with defaultProps 1`] = `
 
 exports[`DataPicker renders with just DataPickerDropdown 1`] = `
 <div
-  className="ax-card ax-card--elevation-x0 ax-card--size-medium ax-card--border ax-card--color-default"
+  className="ax-card ax-card--size-medium ax-card--border ax-card--shade-1"
   onClick={undefined}
 >
   <div
@@ -235,7 +235,7 @@ exports[`DataPicker renders with just DataPickerDropdown 1`] = `
 
 exports[`DataPicker renders with just DataPickerMeta 1`] = `
 <div
-  className="ax-card ax-card--elevation-x0 ax-card--size-medium ax-card--color-darker"
+  className="ax-card ax-card--size-medium ax-card--shade-3"
   onClick={undefined}
 >
   <div
@@ -304,7 +304,7 @@ exports[`DataPicker renders with just DataPickerMeta 1`] = `
 
 exports[`DataPicker renders with onSelectColor 1`] = `
 <div
-  className="ax-card ax-card--elevation-x0 ax-card--size-medium ax-card--border ax-card--color-default"
+  className="ax-card ax-card--size-medium ax-card--border ax-card--shade-1"
   onClick={undefined}
 >
   <div
@@ -425,7 +425,7 @@ exports[`DataPicker renders with onSelectColor 1`] = `
 
 exports[`DataPicker renders with value 1`] = `
 <div
-  className="ax-card ax-card--elevation-x0 ax-card--size-medium ax-card--border ax-card--color-default"
+  className="ax-card ax-card--size-medium ax-card--border ax-card--shade-1"
   onClick={undefined}
 >
   <div

--- a/packages/axiom-components/src/Dialog/Dialog.js
+++ b/packages/axiom-components/src/Dialog/Dialog.js
@@ -15,6 +15,15 @@ export default class Dialog extends Component {
     isOpen: PropTypes.bool.isRequired,
     /** Callback for closing the Dialog by clicking on the overlay */
     onRequestClose: PropTypes.func.isRequired,
+    /** Overlay shade */
+    overlayShade: PropTypes.oneOf([
+      'shade-1',
+      'shade-2',
+      'shade-3',
+      'shade-4',
+    ]),
+    /** Theme applied to the overlay */
+    overlayTheme: PropTypes.oneOf(['day', 'night']),
     /** Maximum size of the Dialog */
     size: PropTypes.oneOf(['small', 'medium', 'large']),
     /** Theme of the dialog */
@@ -42,6 +51,8 @@ export default class Dialog extends Component {
       size,
       fullscreen,
       onRequestClose,
+      overlayShade,
+      overlayTheme,
       theme,
       ...rest
     } = this.props;
@@ -52,7 +63,10 @@ export default class Dialog extends Component {
     });
 
     return (
-      <Modal { ...rest } onOverlayClick={ onRequestClose }>
+      <Modal { ...rest }
+          onOverlayClick={ onRequestClose }
+          overlayShade={ overlayShade }
+          overlayTheme={ overlayTheme }>
         <Base className={ classes } theme={ theme }>
           { children }
         </Base>

--- a/packages/axiom-components/src/Modal/Modal.css
+++ b/packages/axiom-components/src/Modal/Modal.css
@@ -11,8 +11,20 @@
   z-index: var(--z-index-modal);
 }
 
-.ax-modal__container--overlay {
-  background-color: rgba(var(--rgb-ui-carbon), 0.3);
+.ax-modal__container--overlay-shade-1 {
+  background-color: rgba(var(--rgb-theme-background--shade-1), var(--opacity-background--overlay-modal));
+}
+
+.ax-modal__container--overlay-shade-2 {
+  background-color: rgba(var(--rgb-theme-background--shade-2), var(--opacity-background--overlay-modal));
+}
+
+.ax-modal__container--overlay-shade-3 {
+  background-color: rgba(var(--rgb-theme-background--shade-3), var(--opacity-background--overlay-modal));
+}
+
+.ax-modal__container--overlay-shade-4 {
+  background-color: rgba(var(--rgb-theme-background--shade-4), var(--opacity-background--overlay-modal));
 }
 
 .ax-modal {

--- a/packages/axiom-components/src/Modal/Modal.js
+++ b/packages/axiom-components/src/Modal/Modal.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
+import Base from '../Base/Base';
 import Portal from '../Portal/Portal';
 import './Modal.css';
 
@@ -19,11 +20,17 @@ export default class Modal extends Component {
     children: PropTypes.node,
     isOpen: PropTypes.bool.isRequired,
     onOverlayClick: PropTypes.func,
-    withOverlay: PropTypes.bool,
+    overlayShade: PropTypes.oneOf([
+      'shade-1',
+      'shade-2',
+      'shade-3',
+      'shade-4',
+    ]),
+    overlayTheme: PropTypes.oneOf(['day', 'night']),
   };
 
   static defaultProps = {
-    withOverlay: true,
+    overlayShade: 'shade-2',
   };
 
   componentDidMount() {
@@ -45,14 +52,21 @@ export default class Modal extends Component {
   }
 
   render() {
-    const { children, isOpen, withOverlay, onOverlayClick } = this.props;
+    const {
+      children,
+      isOpen,
+      overlayShade,
+      overlayTheme,
+      onOverlayClick,
+    } = this.props;
+
     const classes = classnames('ax-modal__container', {
-      'ax-modal__container--overlay': withOverlay,
+      [`ax-modal__container--overlay-${overlayShade}`]: overlayShade,
     });
 
     return isOpen ? (
       <Portal>
-        <div className={ classes }>
+        <Base className={ classes } theme={ overlayTheme }>
           { onOverlayClick && (
             <div className="ax-modal__mask" onClick={ onOverlayClick } />
           ) }
@@ -60,7 +74,7 @@ export default class Modal extends Component {
           <div className="ax-modal">
             { children }
           </div>
-        </div>
+        </Base>
       </Portal>
     ) : null;
   }

--- a/packages/axiom-components/src/Platform/ConsoleHeader.js
+++ b/packages/axiom-components/src/Platform/ConsoleHeader.js
@@ -11,6 +11,7 @@ export default class ConsoleHeader extends Component {
   static propTypes = {
     children: PropTypes.node,
     separator: PropTypes.bool,
+    shade: PropTypes.oneOf(['shade-4']),
     size: PropTypes.oneOf(['small', 'large']),
   };
 
@@ -25,11 +26,12 @@ export default class ConsoleHeader extends Component {
 
   render() {
     const { onConsoleClose, consolePosition } = this.context;
-    const { children, separator, size, ...rest } = this.props;
+    const { children, separator, shade, size, ...rest } = this.props;
     const classes = classnames(
       'ax-platform__console-header',
       `ax-platform__console-header--${size}`, {
         'ax-platform__console-header--separator': separator,
+        [`ax-platform__console-header--${shade}`]: shade,
       },
     );
 

--- a/packages/axiom-components/src/Platform/ConsoleMenu.css
+++ b/packages/axiom-components/src/Platform/ConsoleMenu.css
@@ -24,9 +24,14 @@
   transition-timing-function: var(--transition-function);
 }
 
-.ax-console-menu__item:hover,
-.ax-console-menu__item--active {
-  background-color: var(--color-theme-background--subtle);
+.ax-console-menu__item:hover {
+  background-color: var(--color-theme-background--hover);
+}
+
+.ax-console-menu__item:active,
+.ax-console-menu__item--active,
+.ax-console-menu__item--active:hover {
+  background-color: var(--color-theme-background--active);
 }
 
 .ax-console-menu__item--disabed,

--- a/packages/axiom-components/src/Platform/Platform.css
+++ b/packages/axiom-components/src/Platform/Platform.css
@@ -79,10 +79,13 @@
   color: var(--color-theme-text);
 }
 
+.ax-platform__console-header--shade-4 {
+  background-color: var(--color-theme-background--shade-4);
+}
+
 .ax-platform,
 .ax-platform__canvas,
 .ax-platform__canvas-header {
-  background-color: var(--color-theme-background);
   color: var(--color-theme-text);
 }
 
@@ -93,6 +96,18 @@
   flex-direction: column;
   justify-content: center;
   padding: 0 var(--page-padding-horizontal);
+}
+
+.ax-platform--shade-1.ax-platform,
+.ax-platform--shade-1 .ax-platform__canvas,
+.ax-platform--shade-1 .ax-platform__canvas-header {
+  background-color: var(--color-theme-background--shade-1);
+}
+
+.ax-platform--shade-2.ax-platform,
+.ax-platform--shade-2 .ax-platform__canvas,
+.ax-platform--shade-2 .ax-platform__canvas-header {
+  background-color: var(--color-theme-background--shade-2);
 }
 
 .ax-platform__console-header--separator,

--- a/packages/axiom-components/src/Platform/Platform.css
+++ b/packages/axiom-components/src/Platform/Platform.css
@@ -75,7 +75,7 @@
 
 .ax-platform__console,
 .ax-platform__console-header {
-  background-color: var(--color-theme-background--active);
+  background-color: var(--color-theme-background--shade-3);
   color: var(--color-theme-text);
 }
 

--- a/packages/axiom-components/src/Platform/Platform.js
+++ b/packages/axiom-components/src/Platform/Platform.js
@@ -12,6 +12,11 @@ export default class Platform extends Component {
     openConsolePosition: PropTypes.oneOf(['left', 'right']),
     openConsoleWidth: PropTypes.string,
     responsive: PropTypes.bool,
+    shade: PropTypes.oneOf(['shade-1', 'shade-2']),
+  };
+
+  static defaultProps = {
+    shade: 'shade-1',
   };
 
   static childContextTypes = {
@@ -34,6 +39,7 @@ export default class Platform extends Component {
       onConsoleClose,
       openConsolePosition,
       responsive,
+      shade,
       ...rest
     } = this.props;
 
@@ -41,7 +47,7 @@ export default class Platform extends Component {
       'openConsoleWidth',
     ]);
 
-    const classes = classnames('ax-platform', {
+    const classes = classnames('ax-platform', `ax-platform--${shade}`, {
       'ax-platform--responsive': responsive,
       'ax-platform--console-open': openConsolePosition,
     });

--- a/packages/axiom-documentation-viewer/src/DocumentationMenu.css
+++ b/packages/axiom-documentation-viewer/src/DocumentationMenu.css
@@ -11,13 +11,14 @@
   transition-timing-function: var(--transition-function);
 
   &:hover {
-    color: var(--color-ui-accent--hover);
+    background-color: var(--color-theme-background--hover);
   }
 }
 
-.ax-documentation-viewer__menu-item--active {
+.ax-documentation-viewer__menu-item--active,
+.ax-documentation-viewer__menu-item--active:hover {
   border-right-color: var(--color-ui-accent--active);
-  background-color: var(--color-theme-background--disabled);
+  background-color: var(--color-theme-background--active);
   color: var(--color-ui-accent--hover);
 }
 

--- a/packages/axiom-documentation-viewer/src/DocumentationShowCase.js
+++ b/packages/axiom-documentation-viewer/src/DocumentationShowCase.js
@@ -56,7 +56,7 @@ export default class DocumentationShowCase extends Component {
     super(props);
     this.state = {
       isCodeVisisble: false,
-      theme: 'day',
+      theme: undefined,
     };
   }
 
@@ -141,8 +141,22 @@ export default class DocumentationShowCase extends Component {
           <CardContent size="small">
             <Grid responsive={ false } verticalAlign="middle">
               <GridCell>
-                { (onRefresh || configurations || hasCustomPropertySupport) && (
+                { (onRefresh || configurations || (!hidePreview && hasCustomPropertySupport)) && (
                   <List style="inline">
+                    { (!hidePreview && hasCustomPropertySupport) && (
+                      <ListItem>
+                        <Link
+                            onClick={ () => this.setState({ theme: 'day' }) }
+                            style={ theme === 'day' ? 'normal' : 'subtle' }>
+                          <Icon inline name="sun" />
+                        </Link> / <Link
+                            onClick={ () => this.setState({ theme: 'night' }) }
+                            style={ theme === 'night' ? 'normal' : 'subtle' }>
+                          <Icon inline name="moon" />
+                        </Link>
+                      </ListItem>
+                    ) }
+
                     { configurations && (
                       <ListItem>
                         <Dropdown flip="mirror">
@@ -173,20 +187,6 @@ export default class DocumentationShowCase extends Component {
                       <ListItem>
                         <Link onClick={ onRefresh } style="subtle">
                           <Icon name="retweet" />
-                        </Link>
-                      </ListItem>
-                    ) }
-
-                    { hasCustomPropertySupport && (
-                      <ListItem>
-                        <Link
-                            onClick={ () => this.setState({ theme: 'day' }) }
-                            style={ theme === 'day' ? 'normal' : 'subtle' }>
-                          <Icon inline name="sun" />
-                        </Link> / <Link
-                            onClick={ () => this.setState({ theme: 'night' }) }
-                            style={ theme === 'night' ? 'normal' : 'subtle' }>
-                          <Icon inline name="moon" />
                         </Link>
                       </ListItem>
                     ) }

--- a/packages/axiom-documentation-viewer/src/DocumentationShowCase.js
+++ b/packages/axiom-documentation-viewer/src/DocumentationShowCase.js
@@ -101,7 +101,7 @@ export default class DocumentationShowCase extends Component {
     }
 
     return (
-      <Card border elevation="x2" space="x8" theme={ theme }>
+      <Card border space="x8" theme={ theme }>
         <CardContent separatorStyle="dotted" size="large">
           <Base cloak={ hidePreview || isCodeVisisble }>
             { (!centeredHorizontal && !centeredVertical) ? (

--- a/packages/axiom-materials/src/colors.css
+++ b/packages/axiom-materials/src/colors.css
@@ -1,12 +1,15 @@
 /* stylelint-disable max-line-length */
 :root {
-  --rgb-ui-carbon--darker: 48, 45, 53;
-  --rgb-ui-carbon--dark: 57, 55, 62;
-  --rgb-ui-carbon: 72, 70, 77;
+  --rgb-ui-carbon--darker: 43, 43, 43;
+  --rgb-ui-carbon--dark: 53, 53, 53;
+  --rgb-ui-carbon: 63, 63, 63;
 
-  --rgb-ui-white-noise--darker: 227, 225, 232;
-  --rgb-ui-white-noise--dark: 237, 235, 242;
-  --rgb-ui-white-noise: 247, 245, 252;
+  --rgb-ui-white-noise--darker: 228, 228, 228;
+  --rgb-ui-white-noise--dark: 238, 238, 238;
+  --rgb-ui-white-noise: 248, 248, 248;
+
+  --rgb-ui-white: 255, 255, 255;
+  --rgb-ui-black: 33, 33, 33;
 
   --rgb-ui-accent--hover: 48, 171, 232;
   --rgb-ui-accent: 35, 158, 219;
@@ -36,6 +39,9 @@
   --color-ui-white-noise--dark: rgb(var(--rgb-ui-white-noise--dark));
   --color-ui-white-noise: rgb(var(--rgb-ui-white-noise));
 
+  --color-ui-black: rgb(var(--rgb-ui-black));
+  --color-ui-white: rgb(var(--rgb-ui-white));
+
   --color-ui-accent--active: rgb(var(--rgb-ui-accent--active));
   --color-ui-accent: rgb(var(--rgb-ui-accent));
   --color-ui-accent--hover: rgb(var(--rgb-ui-accent--hover));
@@ -55,9 +61,6 @@
   --color-ui-info--hover: rgb(var(--rgb-ui-info--hover));
   --color-ui-info: rgb(var(--rgb-ui-info));
   --color-ui-info--active: rgb(var(--rgb-ui-info--active));
-
-  --color-ui-black: rgb(33, 33, 33);
-  --color-ui-white: rgb(255, 255, 255);
 
   --color-ui-highlight: rgb(215, 255, 0);
 

--- a/packages/axiom-materials/src/colors.js
+++ b/packages/axiom-materials/src/colors.js
@@ -1,3 +1,15 @@
+import {
+  opacityTextSubtle,
+  opacityTextDisabled,
+  opacityBackgroundOverlayHeavy,
+  opacityBackgroundOverlayLight,
+  opacityBackgroundSubtle,
+  opacityBackgroundActive,
+  opacityBackgroundDisabled,
+  opacityBackgroundHover,
+  opacityBorder,
+} from './opacities';
+
 export const uiCarbon = { r: 72, g: 70, b: 77 };
 export const uiCarbonDark = { r: 57, g: 55, b: 62 };
 export const uiCarbonDarker = { r: 48, g: 45, b: 53 };
@@ -120,6 +132,40 @@ export const socialFacebook = { r: 59, g: 89, b: 152 };
 export const socialInstagram = { r: 183, g: 71, b: 146 };
 
 export const externalTwiiterBlue = socialTwitter;
+
+export const themeDayMain = uiCarbon;
+export const themeDayMainDark = uiCarbonDark;
+export const themeDayMainDarker = uiCarbonDarker;
+
+export const themeDayText = themeDayMain;
+export const themeDayTextSubtle = { ...themeDayMain, a: opacityTextSubtle };
+export const themeDayTextDisabled = { ...themeDayMain, a: opacityTextDisabled };
+
+export const themeDayBackgroundOverlayHeavy = { ...themeDayMain, a: opacityBackgroundOverlayHeavy };
+export const themeDayBackgroundOverlayLight = { ...themeDayMain, a: opacityBackgroundOverlayLight };
+export const themeDayBackgroundSubtle = { ...themeDayMain, a: opacityBackgroundSubtle };
+export const themeDayBackgroundActive = { ...themeDayMain, a: opacityBackgroundActive };
+export const themeDayBackgroundDisabled = { ...themeDayMain, a: opacityBackgroundDisabled };
+export const themeDayBackgroundHover = { ...themeDayMain, a: opacityBackgroundHover };
+
+export const themeDayBorder = { ...themeDayMain, a: opacityBorder };
+
+export const themeNightMain = uiWhiteNoise;
+export const themeNightMainDark = uiWhiteNoiseDark;
+export const themeNightMainDarker = uiWhiteNoiseDarker;
+
+export const themeNightText = themeNightMain;
+export const themeNightTextSubtle = { ...themeNightMain, a: opacityTextSubtle };
+export const themeNightTextDisabled = { ...themeNightMain, a: opacityTextDisabled };
+
+export const themeNightBackgroundOverlayHeavy = { ...themeNightMain, a: opacityBackgroundOverlayHeavy };
+export const themeNightBackgroundOverlayLight = { ...themeNightMain, a: opacityBackgroundOverlayLight };
+export const themeNightBackgroundSubtle = { ...themeNightMain, a: opacityBackgroundSubtle };
+export const themeNightBackgroundActive = { ...themeNightMain, a: opacityBackgroundActive };
+export const themeNightBackgroundDisabled = { ...themeNightMain, a: opacityBackgroundDisabled };
+export const themeNightBackgroundHover = { ...themeNightMain, a: opacityBackgroundHover };
+
+export const themeNightBorder = { ...themeNightMain, a: opacityBorder };
 
 export const productColorNames = {
   'tiny-clanger': 'Tiny Clanger',

--- a/packages/axiom-materials/src/index.js
+++ b/packages/axiom-materials/src/index.js
@@ -1,7 +1,8 @@
 import * as colors from './colors';
+import * as opacities from './opacities';
 
 export { default as animations } from './animations';
 export { colors as colors };
 export { default as layout } from './layout';
-export { default as opacities } from './opacities';
+export { opacities as opacities };
 export { default as importCssVariables } from './importCssVariables';

--- a/packages/axiom-materials/src/opacities.css
+++ b/packages/axiom-materials/src/opacities.css
@@ -2,10 +2,13 @@
   --opacity-text--subtle: 0.75;
   --opacity-text--disabled: 0.3;
 
+  --opacity-background--overlay-modal: 0.9;
   --opacity-background--overlay-heavy: 0.75;
   --opacity-background--overlay-light: 0.3;
   --opacity-background--subtle: 0.15;
+  --opacity-background--active: 0.08;
   --opacity-background--disabled: 0.05;
+  --opacity-background--hover: 0.04;
 
   --opacity-border: 0.2;
 

--- a/packages/axiom-materials/src/opacities.css
+++ b/packages/axiom-materials/src/opacities.css
@@ -12,7 +12,8 @@
 
   --opacity-border: 0.2;
 
-  --opacity-shadow: 0.1;
+  --opacity-shadow--light: 0.14;
+  --opacity-shadow--heavy: 0.15;
 
   --opacity-input-border--focused: 0.5;
   --opacity-input-border--valid: 0.4;

--- a/packages/axiom-materials/src/opacities.js
+++ b/packages/axiom-materials/src/opacities.js
@@ -1,13 +1,14 @@
-export default {
-  opacityTextSubtle: 0.75,
-  opacityTextDisabled: 0.3,
-  opacityBackgroundOverlayHeavy: 0.75,
-  opacityBackgroundOverlayLight: 0.3,
-  opacityBackgroundSubtle: 0.15,
-  opacityBackgroundDisabled: 0.05,
-  opacityBorder: 0.2,
-  opacityShadow: 0.1,
-  opacityInputBorderFocused: 0.5,
-  opacityInputBorderValid: 0.4,
-  opacityInputBorderInvalid: 0.25,
-};
+export const opacityTextSubtle = 0.75;
+export const opacityTextDisabled = 0.3;
+export const opacityBackgroundOverlayModal = 0.9;
+export const opacityBackgroundOverlayHeavy = 0.75;
+export const opacityBackgroundOverlayLight = 0.3;
+export const opacityBackgroundSubtle = 0.15;
+export const opacityBackgroundActive = 0.08;
+export const opacityBackgroundDisabled = 0.05;
+export const opacityBackgroundHover = 0.04;
+export const opacityBorder = 0.2;
+export const opacityShadow = 0.1;
+export const opacityInputBorderFocused = 0.5;
+export const opacityInputBorderValid = 0.4;
+export const opacityInputBorderInvalid = 0.25;

--- a/packages/axiom-materials/src/sizing.css
+++ b/packages/axiom-materials/src/sizing.css
@@ -38,8 +38,9 @@
   --component-round-size-huge: calc(var(--spacing-grid-size) * 30);
 
   --drop-shadow-border: 0 0 0 0.0625rem;
-  --drop-shadow-elevation--x1: 0 0.0625rem 0.01875rem 0;
-  --drop-shadow-elevation--x2: 0 0.125rem 1rem 0;
+  --drop-shadow-definition: 0 0.0625rem 0.125rem 0.03125rem;
+  --drop-shadow-elevation--x1: 0 0.0625rem 0.1875rem 0;
+  --drop-shadow-elevation--x2: 0 0.25rem 0.5625rem 0;
 
   /**
    * Chart variables.

--- a/packages/axiom-materials/src/theme-day.css
+++ b/packages/axiom-materials/src/theme-day.css
@@ -32,17 +32,17 @@
 
   --color-theme-day-border: rgba(var(--rgb-theme-day-main), var(--opacity-border));
 
-  --color-theme-day-shadow: rgba(var(--rgb-theme-day-main--dark), var(--opacity-shadow));
   --color-theme-day-shadow--border: rgba(var(--rgb-theme-day-main), var(--opacity-border));
+  --color-theme-day-shadow--light: rgba(var(--rgb-theme-day-main), var(--opacity-shadow--light));
+  --color-theme-day-shadow--heavy: rgba(var(--rgb-theme-day-main), var(--opacity-shadow--heavy));
 
   --drop-shadow-theme-day-border: var(--drop-shadow-border) var(--color-theme-day-shadow--border);
-  --drop-shadow-theme-day-elevation--x1: var(--drop-shadow-elevation--x1) var(--color-theme-day-shadow);
-  --drop-shadow-theme-day-elevation--x2: var(--drop-shadow-elevation--x2) var(--color-theme-day-shadow);
-
-  --color-theme-day-card-background: var(--color-ui-white);
-  --color-theme-day-card-background--active: var(--color-ui-white-noise);
-  --color-theme-day-card-background--dark: var(--color-ui-white-noise);
-  --color-theme-day-card-background--darker: var(--color-ui-white-noise--dark);
+  --drop-shadow-theme-day-elevation--x1:
+    var(--drop-shadow-elevation--x1) var(--color-theme-day-shadow--light),
+    var(--drop-shadow-definition) var(--color-theme-day-shadow--heavy);
+  --drop-shadow-theme-day-elevation--x2:
+    var(--drop-shadow-elevation--x2) var(--color-theme-day-shadow--light),
+    var(--drop-shadow-definition) var(--color-theme-day-shadow--heavy);
 }
 
 .ax-theme--day {
@@ -78,15 +78,11 @@
 
   --color-theme-border: var(--color-theme-day-border);
 
-  --color-theme-shadow: var(--color-theme-day-shadow);
   --color-theme-shadow--border: var(--color-theme-day-shadow--border);
+  --color-theme-shadow--light: var(--color-theme-day-shadow--heavy);
+  --color-theme-shadow--heavy: var(--color-theme-day-shadow--light);
 
   --drop-shadow-theme-border: var(--drop-shadow-theme-day-border);
   --drop-shadow-theme-elevation--x1: var(--drop-shadow-theme-day-elevation--x1);
   --drop-shadow-theme-elevation--x2: var(--drop-shadow-theme-day-elevation--x2);
-
-  --color-theme-card-background: var(--color-theme-day-card-background);
-  --color-theme-card-background--active: var(--color-theme-day-card-background--active);
-  --color-theme-card-background--dark: var(--color-theme-day-card-background--dark);
-  --color-theme-card-background--darker: var(--color-theme-day-card-background--darker);
 }

--- a/packages/axiom-materials/src/theme-day.css
+++ b/packages/axiom-materials/src/theme-day.css
@@ -4,6 +4,11 @@
   --rgb-theme-day-main--dark: var(--rgb-ui-carbon--dark);
   --rgb-theme-day-main--darker: var(--rgb-ui-carbon--darker);
 
+  --rgb-theme-day-background--shade-1: var(--rgb-ui-white);
+  --rgb-theme-day-background--shade-2: var(--rgb-ui-white-noise);
+  --rgb-theme-day-background--shade-3: var(--rgb-ui-white-noise--dark);
+  --rgb-theme-day-background--shade-4: var(--rgb-ui-white-noise--darker);
+
   --color-theme-day-main: rgb(var(--rgb-theme-day-main));
   --color-theme-day-main--dark: rgb(var(--rgb-theme-day-main--dark));
   --color-theme-day-main--darker: rgb(var(--rgb-theme-day-main--darker));
@@ -12,13 +17,18 @@
   --color-theme-day-text--subtle: rgba(var(--rgb-theme-day-main), var(--opacity-text--subtle));
   --color-theme-day-text--disabled: rgba(var(--rgb-theme-day-main), var(--opacity-text--disabled));
 
-  --color-theme-day-background--active: var(--color-ui-white-noise--dark);
-  --color-theme-day-background: var(--color-ui-white);
-  --color-theme-day-background--hover: var(--color-ui-white-noise);
+  --color-theme-day-background--shade-1: rgb(var(--rgb-theme-day-background--shade-1));
+  --color-theme-day-background--shade-2: rgb(var(--rgb-theme-day-background--shade-2));
+  --color-theme-day-background--shade-3: rgb(var(--rgb-theme-day-background--shade-3));
+  --color-theme-day-background--shade-4: rgb(var(--rgb-theme-day-background--shade-4));
+
+  --color-theme-day-background: var(--color-theme-day-background--shade-1);
   --color-theme-day-background--overlay-heavy: rgba(var(--rgb-theme-day-main), var(--opacity-background--overlay-heavy));
   --color-theme-day-background--overlay-light: rgba(var(--rgb-theme-day-main), var(--opacity-background--overlay-light));
   --color-theme-day-background--subtle: rgba(var(--rgb-theme-day-main), var(--opacity-background--subtle));
+  --color-theme-day-background--active: rgba(var(--rgb-theme-day-main), var(--opacity-background--active));
   --color-theme-day-background--disabled: rgba(var(--rgb-theme-day-main), var(--opacity-background--disabled));
+  --color-theme-day-background--hover: rgba(var(--rgb-theme-day-main), var(--opacity-background--hover));
 
   --color-theme-day-border: rgba(var(--rgb-theme-day-main), var(--opacity-border));
 
@@ -40,6 +50,11 @@
   --rgb-theme-main--dark: var(--rgb-theme-day-main--dark);
   --rgb-theme-main--darker: var(--rgb-theme-day-main--darker);
 
+  --rgb-theme-background--shade-1: var(--rgb-theme-day-background--shade-1);
+  --rgb-theme-background--shade-2: var(--rgb-theme-day-background--shade-2);
+  --rgb-theme-background--shade-3: var(--rgb-theme-day-background--shade-3);
+  --rgb-theme-background--shade-4: var(--rgb-theme-day-background--shade-4);
+
   --color-theme-main: var(--color-theme-day-main);
   --color-theme-main--dark: var(--color-theme-day-main--dark);
   --color-theme-main--darker: var(--color-theme-day-main--darker);
@@ -48,13 +63,18 @@
   --color-theme-text--subtle: var(--color-theme-day-text--subtle);
   --color-theme-text--disabled: var(--color-theme-day-text--disabled);
 
-  --color-theme-background--active: var(--color-theme-day-background--active);
+  --color-theme-background--shade-1: var(--color-theme-day-background--shade-1);
+  --color-theme-background--shade-2: var(--color-theme-day-background--shade-2);
+  --color-theme-background--shade-3: var(--color-theme-day-background--shade-3);
+  --color-theme-background--shade-4: var(--color-theme-day-background--shade-4);
+
   --color-theme-background: var(--color-theme-day-background);
-  --color-theme-background--hover: var(--color-theme-day-background--hover);
   --color-theme-background--overlay-heavy: var(--color-theme-day-background--overlay-heavy);
   --color-theme-background--overlay-light: var(--color-theme-day-background--overlay-light);
   --color-theme-background--subtle: var(--color-theme-day-background--subtle);
+  --color-theme-background--active: var(--color-theme-day-background--active);
   --color-theme-background--disabled: var(--color-theme-day-background--disabled);
+  --color-theme-background--hover: var(--color-theme-day-background--hover);
 
   --color-theme-border: var(--color-theme-day-border);
 

--- a/packages/axiom-materials/src/theme-night.css
+++ b/packages/axiom-materials/src/theme-night.css
@@ -32,17 +32,17 @@
 
   --color-theme-night-border: rgba(var(--rgb-theme-night-main), var(--opacity-border));
 
-  --color-theme-night-shadow: rgba(var(--rgb-ui-black), var(--opacity-shadow));
   --color-theme-night-shadow--border: rgba(var(--rgb-theme-night-main), var(--opacity-border));
+  --color-theme-night-shadow--light: rgba(var(--rgb-ui-black), var(--opacity-shadow--light));
+  --color-theme-night-shadow--heavy: rgba(var(--rgb-ui-black), var(--opacity-shadow--heavy));
 
   --drop-shadow-theme-night-border: var(--drop-shadow-border) var(--color-theme-night-shadow--border);
-  --drop-shadow-theme-night-elevation--x1: var(--drop-shadow-elevation--x1) var(--color-theme-night-shadow);
-  --drop-shadow-theme-night-elevation--x2: var(--drop-shadow-elevation--x2) var(--color-theme-night-shadow);
-
-  --color-theme-night-card-background: var(--color-ui-carbon);
-  --color-theme-night-card-background--active: var(--color-ui-carbon--dark);
-  --color-theme-night-card-background--dark: var(--color-ui-carbon--dark);
-  --color-theme-night-card-background--darker: var(--color-ui-carbon--darker);
+  --drop-shadow-theme-night-elevation--x1:
+    var(--drop-shadow-elevation--x1) var(--color-theme-night-shadow--light),
+    var(--drop-shadow-definition) var(--color-theme-night-shadow--heavy);
+  --drop-shadow-theme-night-elevation--x2:
+    var(--drop-shadow-elevation--x2) var(--color-theme-night-shadow--light),
+    var(--drop-shadow-definition) var(--color-theme-night-shadow--heavy);
 }
 
 .ax-theme--night {
@@ -78,15 +78,11 @@
 
   --color-theme-border: var(--color-theme-night-border);
 
-  --color-theme-shadow: var(--color-theme-night-shadow);
   --color-theme-shadow--border: var(--color-theme-night-shadow--border);
+  --color-theme-shadow--light: var(--color-theme-night-shadow--heavy);
+  --color-theme-shadow--heavy: var(--color-theme-night-shadow--light);
 
   --drop-shadow-theme-border: var(--drop-shadow-theme-night-border);
   --drop-shadow-theme-elevation--x1: var(--drop-shadow-theme-night-elevation--x1);
   --drop-shadow-theme-elevation--x2: var(--drop-shadow-theme-night-elevation--x2);
-
-  --color-theme-card-background: var(--color-theme-night-card-background);
-  --color-theme-card-background--active: var(--color-theme-night-card-background--active);
-  --color-theme-card-background--dark: var(--color-theme-night-card-background--dark);
-  --color-theme-card-background--darker: var(--color-theme-night-card-background--darker);
 }

--- a/packages/axiom-materials/src/theme-night.css
+++ b/packages/axiom-materials/src/theme-night.css
@@ -4,6 +4,11 @@
   --rgb-theme-night-main--dark: var(--rgb-ui-white-noise--dark);
   --rgb-theme-night-main--darker: var(--rgb-ui-white-noise--darker);
 
+  --rgb-theme-night-background--shade-1: var(--rgb-ui-black);
+  --rgb-theme-night-background--shade-2: var(--rgb-ui-carbon--darker);
+  --rgb-theme-night-background--shade-3: var(--rgb-ui-carbon--dark);
+  --rgb-theme-night-background--shade-4: var(--rgb-ui-carbon);
+
   --color-theme-night-main: rgb(var(--rgb-theme-night-main));
   --color-theme-night-main--dark: rgb(var(--rgb-theme-night-main--dark));
   --color-theme-night-main--darker: rgb(var(--rgb-theme-night-main--darker));
@@ -12,18 +17,23 @@
   --color-theme-night-text--subtle: rgba(var(--rgb-theme-night-main), var(--opacity-text--subtle));
   --color-theme-night-text--disabled: rgba(var(--rgb-theme-night-main), var(--opacity-text--disabled));
 
-  --color-theme-night-background--active: var(--color-ui-carbon--dark);
-  --color-theme-night-background: var(--color-ui-carbon--darker);
-  --color-theme-night-background--hover: var(--color-ui-carbon);
+  --color-theme-night-background--shade-1: rgb(var(--rgb-theme-night-background--shade-1));
+  --color-theme-night-background--shade-2: rgb(var(--rgb-theme-night-background--shade-2));
+  --color-theme-night-background--shade-3: rgb(var(--rgb-theme-night-background--shade-3));
+  --color-theme-night-background--shade-4: rgb(var(--rgb-theme-night-background--shade-4));
+
+  --color-theme-night-background: var(--color-theme-night-background--shade-2);
   --color-theme-night-background--overlay-heavy: rgba(var(--rgb-theme-night-main), var(--opacity-background--overlay-heavy));
   --color-theme-night-background--overlay-light: rgba(var(--rgb-theme-night-main), var(--opacity-background--overlay-light));
   --color-theme-night-background--subtle: rgba(var(--rgb-theme-night-main), var(--opacity-background--subtle));
+  --color-theme-night-background--active: rgba(var(--rgb-theme-night-main), var(--opacity-background--active));
   --color-theme-night-background--disabled: rgba(var(--rgb-theme-night-main), var(--opacity-background--disabled));
+  --color-theme-night-background--hover: rgba(var(--rgb-theme-night-main), var(--opacity-background--hover));
 
   --color-theme-night-border: rgba(var(--rgb-theme-night-main), var(--opacity-border));
 
-  --color-theme-night-shadow: rgba(var(--rgb-theme-night-main--dark), 0.1);
-  --color-theme-night-shadow--border: rgba(var(--rgb-theme-night-main), 0.2);
+  --color-theme-night-shadow: rgba(var(--rgb-ui-black), var(--opacity-shadow));
+  --color-theme-night-shadow--border: rgba(var(--rgb-theme-night-main), var(--opacity-border));
 
   --drop-shadow-theme-night-border: var(--drop-shadow-border) var(--color-theme-night-shadow--border);
   --drop-shadow-theme-night-elevation--x1: var(--drop-shadow-elevation--x1) var(--color-theme-night-shadow);
@@ -40,6 +50,11 @@
   --rgb-theme-main--dark: var(--rgb-theme-night-main--dark);
   --rgb-theme-main--darker: var(--rgb-theme-night-main--darker);
 
+  --rgb-theme-background--shade-1: var(--rgb-theme-night-background--shade-1);
+  --rgb-theme-background--shade-2: var(--rgb-theme-night-background--shade-2);
+  --rgb-theme-background--shade-3: var(--rgb-theme-night-background--shade-3);
+  --rgb-theme-background--shade-4: var(--rgb-theme-night-background--shade-4);
+
   --color-theme-main: var(--color-theme-night-main);
   --color-theme-main--dark: var(--color-theme-night-main--dark);
   --color-theme-main--darker: var(--color-theme-night-main--darker);
@@ -48,13 +63,18 @@
   --color-theme-text--subtle: var(--color-theme-night-text--subtle);
   --color-theme-text--disabled: var(--color-theme-night-text--disabled);
 
-  --color-theme-background--active: var(--color-theme-night-background--active);
+  --color-theme-background--shade-1: var(--color-theme-night-background--shade-1);
+  --color-theme-background--shade-2: var(--color-theme-night-background--shade-2);
+  --color-theme-background--shade-3: var(--color-theme-night-background--shade-3);
+  --color-theme-background--shade-4: var(--color-theme-night-background--shade-4);
+
   --color-theme-background: var(--color-theme-night-background);
-  --color-theme-background--hover: var(--color-theme-night-background--hover);
   --color-theme-background--overlay-heavy: var(--color-theme-night-background--overlay-heavy);
   --color-theme-background--overlay-light: var(--color-theme-night-background--overlay-light);
   --color-theme-background--subtle: var(--color-theme-night-background--subtle);
+  --color-theme-background--active: var(--color-theme-night-background--active);
   --color-theme-background--disabled: var(--color-theme-night-background--disabled);
+  --color-theme-background--hover: var(--color-theme-night-background--hover);
 
   --color-theme-border: var(--color-theme-night-border);
 

--- a/site/components/Documentation/Resources/Components/Card.js
+++ b/site/components/Documentation/Resources/Components/Card.js
@@ -1,12 +1,15 @@
 import React, { Component } from 'react';
 import {
   Badge,
+  Candytar,
   Card,
   CardCaption,
   CardContent,
   CardImage,
+  CardList,
   Grid,
   GridCell,
+  Heading,
   Link,
   List,
   ListItem,
@@ -23,9 +26,43 @@ export default class Documentation extends Component {
   render() {
     return (
       <DocumentationContent>
+        <DocumentationShowCase description="The matrix above illustrates the different card
+            styles and configurations achievable. Shaded backgrounds and states are
+            configurable through the props and will alter in the standard way for themes.">
+          <Grid textCenter textColor="subtle">
+            <GridCell>
+              <Heading>Border</Heading>
+              <Card border onClick={ () => {} } space="x4"><CardContent>Default</CardContent></Card>
+              <Card border hover space="x4"><CardContent>Hover</CardContent></Card>
+              <Card active border space="x4"><CardContent>Active</CardContent></Card>
+            </GridCell>
+
+            <GridCell>
+              <Heading>Border & Shadow</Heading>
+              <Card border onClick={ () => {} } shadow space="x4"><CardContent>Default</CardContent></Card>
+              <Card border hover shadow space="x4"><CardContent>Hover</CardContent></Card>
+              <Card active border shadow space="x4"><CardContent>Active</CardContent></Card>
+            </GridCell>
+
+            <GridCell>
+              <Heading>Borderless</Heading>
+              <Card onClick={ () => {} } space="x4"><CardContent>Default</CardContent></Card>
+              <Card hover space="x4"><CardContent>Hover</CardContent></Card>
+              <Card active space="x4"><CardContent>Active</CardContent></Card>
+            </GridCell>
+
+            <GridCell>
+              <Heading>Borderless & Shadow</Heading>
+              <Card onClick={ () => {} } shadow space="x4"><CardContent>Default</CardContent></Card>
+              <Card hover shadow space="x4"><CardContent>Hover</CardContent></Card>
+              <Card active shadow space="x4"><CardContent>Active</CardContent></Card>
+            </GridCell>
+          </Grid>
+        </DocumentationShowCase>
+
         <DocumentationShowCase>
           <div style={ { margin: 'auto', maxWidth: '16.375rem' } }>
-            <Card border elevation="x1" onClick={ () => {} }>
+            <Card onClick={ () => {} } shadow>
               <CardImage src="/assets/card.jpg">
                 <CardCaption textStrong>
                   <List style="inline">
@@ -81,6 +118,64 @@ export default class Documentation extends Component {
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Card/CardContent'),
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Card/CardImage'),
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Card/CardCaption'),
+        ] } />
+
+        <DocumentationShowCase>
+          <CardList>
+            <Card onClick={ () => {} }>
+              <CardContent>
+                <Grid>
+                  <GridCell none>
+                    <Candytar size="4rem" />
+                  </GridCell>
+                  <GridCell>
+                    <Heading textStrong>Lorem ipsum</Heading>
+                    <Paragraph>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce at
+                      pretium erat. Aenean placerat quam leo, eu consequat sem malesuada varius.
+                      In vitae nunc ut elit auctor semper eget eu ex. Sed ultricies placerat lectus,
+                      quis venenatis metus sagittis egestas.</Paragraph>
+                  </GridCell>
+                </Grid>
+              </CardContent>
+            </Card>
+
+            <Card onClick={ () => {} }>
+              <CardContent>
+                <Grid>
+                  <GridCell none>
+                    <Candytar size="4rem" />
+                  </GridCell>
+                  <GridCell>
+                    <Heading textStrong>Lorem ipsum</Heading>
+                    <Paragraph>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce at
+                      pretium erat. Aenean placerat quam leo, eu consequat sem malesuada varius.
+                      In vitae nunc ut elit auctor semper eget eu ex. Sed ultricies placerat lectus,
+                      quis venenatis metus sagittis egestas.</Paragraph>
+                  </GridCell>
+                </Grid>
+              </CardContent>
+            </Card>
+
+            <Card onClick={ () => {} }>
+              <CardContent>
+                <Grid>
+                  <GridCell none>
+                    <Candytar size="4rem" />
+                  </GridCell>
+                  <GridCell>
+                    <Heading textStrong>Lorem ipsum</Heading>
+                    <Paragraph>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce at
+                      pretium erat. Aenean placerat quam leo, eu consequat sem malesuada varius.
+                      In vitae nunc ut elit auctor semper eget eu ex. Sed ultricies placerat lectus,
+                      quis venenatis metus sagittis egestas.</Paragraph>
+                  </GridCell>
+                </Grid>
+              </CardContent>
+            </Card>
+          </CardList>
+        </DocumentationShowCase>
+
+        <DocumentationApi components={ [
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Card/CardList'),
         ] } />
       </DocumentationContent>

--- a/site/components/Documentation/Resources/Materials.js
+++ b/site/components/Documentation/Resources/Materials.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { DocumentationViewer } from '@brandwatch/axiom-documentation-viewer';
 import Colors from './Materials/Colors';
+import Themes from './Materials/Themes';
 
 export default class Guidelines extends Component {
   render() {
@@ -10,6 +11,10 @@ export default class Guidelines extends Component {
             id: 'colours',
             name: 'Colours',
             Component: Colors,
+          }, {
+            id: 'themes',
+            name: 'Themes',
+            Component: Themes,
           }] }
           path="/docs/packages/axiom-materials" />
     );

--- a/site/components/Documentation/Resources/Materials/Themes.js
+++ b/site/components/Documentation/Resources/Materials/Themes.js
@@ -1,0 +1,65 @@
+import React, { Component, Fragment } from 'react';
+import { Card, CardContent } from '@brandwatch/axiom-components';
+import { colors } from '@brandwatch/axiom-materials';
+import ColorGrid from './Colors/ColorGrid';
+import ColorSet from './Colors/ColorSet';
+import ColorDot from './Colors/ColorDot';
+import ColorLetter from './Colors/ColorLetter';
+
+export default class Documentation extends Component {
+  render() {
+    return (
+      <Fragment>
+        <Card shadow size="large" theme="night">
+          <CardContent size="large">
+            <ColorGrid name="Night theme">
+              <ColorSet name="Text">
+                <ColorLetter name="Default" rgb={ colors.themeNightText } />
+                <ColorLetter name="Subtle" rgb={ colors.themeNightTextSubtle } />
+                <ColorLetter name="Disabled" rgb={ colors.themeNightTextDisabled } />
+              </ColorSet>
+
+              <ColorSet name="Background">
+                <ColorDot name="Overlay Heavy" rgb={ colors.themeNightBackgroundOverlayHeavy } />
+                <ColorDot name="Overlay Light" rgb={ colors.themeNightBackgroundOverlayLight } />
+                <ColorDot name="Subtle" rgb={ colors.themeNightBackgroundSubtle } />
+                <ColorDot name="Active" rgb={ colors.themeNightBackgroundActive } />
+                <ColorDot name="Disabled" rgb={ colors.themeNightBackgroundDisabled } />
+                <ColorDot name="Hover" rgb={ colors.themeNightBackgroundHover } />
+              </ColorSet>
+
+              <ColorSet name="Border">
+                <ColorDot name="Default" rgb={ colors.themeNightBorder } />
+              </ColorSet>
+            </ColorGrid>
+          </CardContent>
+        </Card>
+
+        <Card shadow size="large" space="x8" theme="day">
+          <CardContent size="large">
+            <ColorGrid name="Day theme">
+              <ColorSet name="Text">
+                <ColorLetter name="Default" rgb={ colors.themeDayText } />
+                <ColorLetter name="Subtle" rgb={ colors.themeDayTextSubtle } />
+                <ColorLetter name="Disabled" rgb={ colors.themeDayTextDisabled } />
+              </ColorSet>
+
+              <ColorSet name="Background">
+                <ColorDot name="Overlay Heavy" rgb={ colors.themeDayBackgroundOverlayHeavy } />
+                <ColorDot name="Overlay Light" rgb={ colors.themeDayBackgroundOverlayLight } />
+                <ColorDot name="Subtle" rgb={ colors.themeDayBackgroundSubtle } />
+                <ColorDot name="Active" rgb={ colors.themeDayBackgroundActive } />
+                <ColorDot name="Disabled" rgb={ colors.themeDayBackgroundDisabled } />
+                <ColorDot name="Hover" rgb={ colors.themeDayBackgroundHover } />
+              </ColorSet>
+
+              <ColorSet name="Border">
+                <ColorDot name="Default" rgb={ colors.themeDayBorder } />
+              </ColorSet>
+            </ColorGrid>
+          </CardContent>
+        </Card>
+      </Fragment>
+    );
+  }
+}


### PR DESCRIPTION
Introduces a better way to handle Cards, Shadows and general variable background colours across the day and night themes. 

Notable breaking changes is mainly around Cards. 

* Configurable elevation is now not a thing. Simply use the flag `shadow` and see the Card matrix in the new documentation. 
* `color` property has been removed as the values did not work for the night theme. Use the new `shade` pattern. 

Other breaking changes that are unlikely to effect anyone updating include, some CSS variable changes and a prop removal from Modal. Please see commit messages and CHANGELOGs for more information. 

[Netlify Deploy](https://new-ui-colours--hhogg-axiom.netlify.com/)