### PR TITLE
fix(axisUtil.getAxisUpper) rounds to same order of magnitude instead 

### DIFF
--- a/packages/axiom-charts/src/utils/axisUtils.js
+++ b/packages/axiom-charts/src/utils/axisUtils.js
@@ -23,12 +23,13 @@ function getOrder(value) {
     return 0;
   }
 
-  return Math.ceil(Math.log10(value));
+  return Math.floor(Math.log10(value));
 }
 
 export function getAxisUpper(values) {
   const max = Math.max.apply(null, values);
-  return Math.pow(10, getOrder(max));
+  const mag = Math.pow(10, getOrder(max));
+  return Math.ceil(max / mag) * mag;
 }
 
 export default {

--- a/packages/axiom-charts/src/utils/axisUtils.test.js
+++ b/packages/axiom-charts/src/utils/axisUtils.test.js
@@ -84,39 +84,58 @@ describe('getEquallyDistributedAxisLabels', () => {
 });
 
 describe('getAxisUpper', () => {
-  it('returns 0.1 when max is below 0.1', () => {
-    expect(getAxisUpper([0, 0.011])).toEqual(0.1);
-    expect(getAxisUpper([0, 0.05, 0.099])).toEqual(0.1);
+  it('returns 0.05 when max is below or equal 0.05', () => {
+    expect(getAxisUpper([0, 0.045])).toEqual(0.05);
+    expect(getAxisUpper([0.040, 0.045])).toEqual(0.05);
+    expect(getAxisUpper([0.04, 0.05])).toEqual(0.05);
+  });
+
+  it('returns 0.1 when max is below or equal 0.1', () => {
+    expect(getAxisUpper([0, 0.099])).toEqual(0.1);
+    expect(getAxisUpper([0, 0.091])).toEqual(0.1);
+    expect(getAxisUpper([0, 0.1])).toEqual(0.1);
+  });
+
+  it('returns 0.2 when max is below or equal 0.2', () => {
+    expect(getAxisUpper([0, 0.11])).toEqual(0.2);
+    expect(getAxisUpper([0, 0.2])).toEqual(0.2);
   });
 
   it('returns 1 when max is below or equal 1', () => {
-    expect(getAxisUpper([0, 0.5])).toEqual(1);
-    expect(getAxisUpper([0, 0.1, 0.2, 0.9])).toEqual(1);
+    expect(getAxisUpper([0, 0.96])).toEqual(1);
     expect(getAxisUpper([0.9999999, 0.90005])).toEqual(1);
     expect(getAxisUpper([0, 1])).toEqual(1);
   });
 
   it('returns 10 when max is below or equal 10', () => {
-    expect(getAxisUpper([1, 0, 9])).toEqual(10);
-    expect(getAxisUpper([10, 0, 9])).toEqual(10);
-    expect(getAxisUpper([0, 0, 10])).toEqual(10);
+    expect(getAxisUpper([1, 0, 9.6])).toEqual(10);
+    expect(getAxisUpper([0, 0, 9.01])).toEqual(10);
+    expect(getAxisUpper([10, 0])).toEqual(10);
   });
 
   it('returns 100 when max is below or equal 100', () => {
-    expect(getAxisUpper([0, 1, 2, 11])).toEqual(100);
+    expect(getAxisUpper([0, 1, 2, 91])).toEqual(100);
     expect(getAxisUpper([20, 99, 50])).toEqual(100);
     expect(getAxisUpper([20, 100])).toEqual(100);
   });
 
+  it('returns 300 when max is below or equal 300', () => {
+    expect(getAxisUpper([0, 201])).toEqual(300);
+  });
+
   it('returns 1000 when max is below or equal 1000', () => {
     expect(getAxisUpper([200, 999, 100])).toEqual(1000);
-    expect(getAxisUpper([200, 201, 101])).toEqual(1000);
     expect(getAxisUpper([200, 1000])).toEqual(1000);
+  });
+
+  it('returns 5000 when max is below or equal 5000', () => {
+    expect(getAxisUpper([20, 40, 4235])).toEqual(5000);
+    expect(getAxisUpper([10, 20, 5000])).toEqual(5000);
   });
 
   it('returns 10000 when max is below 10000', () => {
     expect(getAxisUpper([20, 40, 9999])).toEqual(10000);
-    expect(getAxisUpper([10, 20, 1001])).toEqual(10000);
+    expect(getAxisUpper([10, 20, 9001])).toEqual(10000);
     expect(getAxisUpper([0, 0, 10000])).toEqual(10000);
   });
 


### PR DESCRIPTION
In https://github.com/BrandwatchLtd/axiom/pull/485 `axisUtils.getAxisUpper()` was added which returned an upper of the next magnitude of the maximum e.g. for a max of `101` we returned `1000`. This wastes way too much space on graphs.

This PR changes the behaviour of `axisUtils.getAxisUpper()` to round up to the next multiple of the _same_ magnitude, e.g.

|max|result|
|-|-|
|0.43|0.5|
|3|10|
|203|300|
|950|1000|
