### PR TITLE
fix(BarChart): hide other bars only when BarChart displays multiple bars

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -13,7 +13,7 @@ import ChartTableRows from '../ChartTable/ChartTableRows';
 import ChartTableVisual from '../ChartTable/ChartTableVisual';
 import DataPoint from '../DataPoint/DataPoint';
 import DataPoints from '../DataPoint/DataPoints';
-import { formatData, flattenValues } from './utils';
+import { formatData, flattenValues, hasMultipleValues } from './utils';
 import './BarChart.css';
 
 export default class BarChart extends Component {
@@ -149,6 +149,7 @@ export default class BarChart extends Component {
 
     const { selectedColor, selectedIndex } = this.state;
     const formattedData = formatData(chartKey, data);
+    const isMultipleValuesData = hasMultipleValues(data);
 
     const finalLower = Math.min(lower, dataLower);
     const finalUpper = Math.max(upper, dataUpper);
@@ -184,9 +185,9 @@ export default class BarChart extends Component {
                     benchmarkHeight={ rowSpace }
                     data={ data[index] }
                     fadeBenchmarkLine={ selectedIndex !== null }
-                    hideBars={ selectedIndex !== null && selectedIndex !== index }
+                    hideBars={ isMultipleValuesData && selectedIndex !== null && selectedIndex !== index }
                     hoverColor={ selectedColor }
-                    isHovered={ index === selectedIndex }
+                    isHovered={ isMultipleValuesData && index === selectedIndex }
                     label={ label }
                     lower={ finalLower }
                     onDropdownClose={ () => this.handleDropdonClose() }

--- a/packages/axiom-charts/src/BarChart/utils.js
+++ b/packages/axiom-charts/src/BarChart/utils.js
@@ -20,3 +20,6 @@ export const flattenValues = (data) => {
     return memo;
   }, []);
 };
+
+export const hasMultipleValues = (data) =>
+  data.some(({ values }) => Object.keys(values).length > 1);

--- a/packages/axiom-charts/src/BarChart/utils.test.js
+++ b/packages/axiom-charts/src/BarChart/utils.test.js
@@ -1,4 +1,4 @@
-import { formatData, flattenValues } from './utils';
+import { formatData, flattenValues, hasMultipleValues } from './utils';
 
 const chartKey = [
   { color: 'giant-leap', label: 'Brand A' },
@@ -108,5 +108,29 @@ describe('BarChart (utils)', () => {
 
   it('it gets a flatt list of all values', () => {
     expect(flattenValues(data)).toMatchSnapshot();
+  });
+
+  describe('hasMultipleValues', () => {
+    it('returns true when data has multiple values', () => {
+      expect(hasMultipleValues(data)).toEqual(true);
+    });
+
+    it('returns false when data has just single values', () => {
+      const data = [
+        {
+          label: 'Technology',
+          values: {
+            'giant-leep': 20,
+          },
+        },
+        {
+          label: 'Books',
+          values: {
+            'serene-sea': 15,
+          },
+        },
+      ];
+      expect(hasMultipleValues(data)).toEqual(false);
+    });
   });
 });


### PR DESCRIPTION
When using the BarChart with multiple bars per label and hovering over a single bar on a label, other bars on that label are dimmed and on other labels the bars of different colour are hidden.

#### hover on BarChart with multiple bars per label

![multiple-as-before](https://user-images.githubusercontent.com/111471/37970463-d81bb9c2-31d3-11e8-93b4-4a33890cc8dc.gif)

#### hover on BarChart with one bar per label

This does not make sense if you use just one bar per label, as there is no need to focus the users attention:
![old](https://user-images.githubusercontent.com/111471/37972079-cb6d56aa-31d7-11e8-847c-7c1db0d3d835.gif)


With this PR the BarChart will not hide if there is just **one** bar per label. If any label has more than one bar, the behaviour is the same as before.
![new](https://user-images.githubusercontent.com/111471/37972090-d162e94e-31d7-11e8-92f5-b6d0f742a36b.gif)



