### PR TITLE
Validate commit message to ensure correct format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
 before_script:
 - yarn ci:setup
 script:
+- yarn lint:commits
 - yarn lint
 - yarn ci:test
 after_success:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "yarn run lint:js && yarn run lint:css",
     "lint:css": "stylelint 'packages/**/*.css' 'site/**/*.css'",
     "lint:js": "eslint --config .eslintrc packages site",
+    "lint:commits": "./scripts/validate_commit_messages.sh",
     "publish:packages": "bash ./scripts/publish_packages.sh",
     "publish:site": "bash ./scripts/publish_site.sh",
     "start": "bash ./scripts/start_development.sh",
@@ -65,6 +66,7 @@
     "stylelint": "^7.9.0",
     "stylelint-order": "^0.6.0",
     "uglifyjs-webpack-plugin": "v1.0.0-beta.2",
+    "validate-commit": "^3.4.0",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   }

--- a/scripts/validate_commit_messages.sh
+++ b/scripts/validate_commit_messages.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+IFS=$'\n';
+
+for MSG in $(git log --no-merges --pretty=format:'%s' origin/master...); do
+  yarn validate-commit-msg $MSG || exit 1;
+done


### PR DESCRIPTION
Since we rely on the commit message for auto publishing new versions, we should validate them to ensure a new `npm publish` gets triggered after a PR is merged. 

This build proves that validating is working https://travis-ci.org/BrandwatchLtd/axiom/builds/359252903


