### PR TITLE
STS-81 allow sentiment colors in bar chart

### DIFF
--- a/packages/axiom-charts/src/Bar/Bar.css
+++ b/packages/axiom-charts/src/Bar/Bar.css
@@ -49,6 +49,9 @@
   &.ax-bars__bar-rect--space-oddity { background-color: var(--color-product-space-oddity); }
   &.ax-bars__bar-rect--deep-thought { background-color: var(--color-product-deep-thought); }
   &.ax-bars__bar-rect--luna-dust { background-color: var(--color-product-luna-dust); }
+  &.ax-bars__bar-rect--sentiment-positive { background-color: var(--color-sentiment-positive); }
+  &.ax-bars__bar-rect--sentiment-negative { background-color: var(--color-sentiment-negative); }
+  &.ax-bars__bar-rect--sentiment-neutral { background-color: var(--color-sentiment-neutral); }
 }
 
 .ax-bars__bar--clickable {
@@ -152,6 +155,21 @@
     &.ax-bars__bar-rect--luna-dust {
       &:hover { background-color: var(--color-product-luna-dust--hover); }
       &:active { background-color: var(--color-product-luna-dust--active); }
+    }
+
+    &.ax-bars__bar-rect--sentiment-positive {
+      &:hover { background-color: var(--color-sentiment-positive--hover); }
+      &:active { background-color: var(--color-sentiment-positive--active); }
+    }
+
+    &.ax-bars__bar-rect--sentiment-negative {
+      &:hover { background-color: var(--color-sentiment-negative--hover); }
+      &:active { background-color: var(--color-sentiment-negative--active); }
+    }
+
+    &.ax-bars__bar-rect--sentiment-neutral {
+      &:hover { background-color: var(--color-sentiment-neutral--hover); }
+      &:active { background-color: var(--color-sentiment-neutral--active); }
     }
   }
 }

--- a/packages/axiom-charts/src/Bar/Bar.js
+++ b/packages/axiom-charts/src/Bar/Bar.js
@@ -27,6 +27,9 @@ export default class Bar extends Component {
       'space-oddity',
       'deep-thought',
       'luna-dust',
+      'sentiment-positive',
+      'sentiment-negative',
+      'sentiment-neutral',
     ]).isRequired,
     /** When true the bar is faded */
     isFaded: PropTypes.bool,

--- a/packages/axiom-charts/src/DataPoint/DataPoint.js
+++ b/packages/axiom-charts/src/DataPoint/DataPoint.js
@@ -28,6 +28,9 @@ export default class DataPoint extends Component {
       'space-oddity',
       'deep-thought',
       'luna-dust',
+      'sentiment-positive',
+      'sentiment-negative',
+      'sentiment-neutral',
     ]).isRequired,
     /** SKIP */
     r: PropTypes.number,

--- a/packages/axiom-charts/src/DataPoint/DataPoints.css
+++ b/packages/axiom-charts/src/DataPoint/DataPoints.css
@@ -38,6 +38,9 @@
 .ax-data-point--space-oddity { color: var(--color-product-space-oddity); }
 .ax-data-point--deep-thought { color: var(--color-product-deep-thought); }
 .ax-data-point--luna-dust { color: var(--color-product-luna-dust); }
+.ax-data-point--sentiment-positive { color: var(--color-sentiment-positive); }
+.ax-data-point--sentiment-negative { color: var(--color-sentiment-negative); }
+.ax-data-point--sentiment-neutral { color: var(--color-sentiment-neutral); }
 
 .ax-data-points--clickable {
   cursor: pointer;
@@ -62,6 +65,9 @@
     & .ax-data-point--space-oddity { color: var(--color-product-space-oddity--hover); }
     & .ax-data-point--deep-thought { color: var(--color-product-deep-thought--hover); }
     & .ax-data-point--luna-dust { color: var(--color-product-luna-dust--hover); }
+    & .ax-data-point--sentiment-positive { color: var(--color-sentiment-positive--hover); }
+    & .ax-data-point--sentiment-negative { color: var(--color-sentiment-negative--hover); }
+    & .ax-data-point--sentiment-neutral { color: var(--color-sentiment-neutral--hover); }
   }
 
   &:active {
@@ -84,5 +90,8 @@
     & .ax-data-point--space-oddity { color: var(--color-product-space-oddity--active); }
     & .ax-data-point--deep-thought { color: var(--color-product-deep-thought--active); }
     & .ax-data-point--luna-dust { color: var(--color-product-luna-dust--active); }
+    & .ax-data-point--sentiment-positive { color: var(--color-sentiment-positive--active); }
+    & .ax-data-point--sentiment-negative { color: var(--color-sentiment-negative--active); }
+    & .ax-data-point--sentiment-neutral { color: var(--color-sentiment-neutral--active); }
   }
 }

--- a/packages/axiom-charts/src/Line/Line.css
+++ b/packages/axiom-charts/src/Line/Line.css
@@ -77,3 +77,6 @@
 .ax-line--space-oddity { color: var(--color-product-space-oddity); }
 .ax-line--deep-thought { color: var(--color-product-deep-thought); }
 .ax-line--luna-dust { color: var(--color-product-luna-dust); }
+.ax-line--sentiment-positive { color: var(--color-sentiment-positive); }
+.ax-line--sentiment-negative { color: var(--color-sentiment-negative); }
+.ax-line--sentiment-neutral { color: var(--color-sentiment-neutral); }

--- a/packages/axiom-charts/src/Line/Line.js
+++ b/packages/axiom-charts/src/Line/Line.js
@@ -44,6 +44,9 @@ export default class Line extends Component {
       'space-oddity',
       'deep-thought',
       'luna-dust',
+      'sentiment-positive',
+      'sentiment-negative',
+      'sentiment-neutral',
     ]).isRequired,
     /** Dash length */
     dasharray: PropTypes.string,

--- a/packages/axiom-charts/src/Line/LinePoint.js
+++ b/packages/axiom-charts/src/Line/LinePoint.js
@@ -19,20 +19,30 @@ export default class LinePoint extends Component {
      * been hovered over.
      */
     TooltipContext: PropTypes.func,
-    /** Color of the DatPoint */
+    /** Color of the DataPoint */
     color: PropTypes.oneOf([
       'tiny-clanger',
       'critical-mass',
+      'fantastic-voyage',
       'paradise-lost',
       'serene-sea',
+      'electric-dreams',
       'giant-leap',
       'moon-lagoon',
+      'space-invader',
       'terra-form',
       'primeval-soup',
+      'sun-maker',
       'new-horizon',
       'blast-off',
+      'crash-course',
       'ground-control',
+      'space-oddity',
+      'deep-thought',
       'luna-dust',
+      'sentiment-positive',
+      'sentiment-negative',
+      'sentiment-neutral',
     ]).isRequired,
     /** Applies hover state, useful to retain hover styling. */
     hover: PropTypes.bool,

--- a/packages/axiom-materials/src/colors.css
+++ b/packages/axiom-materials/src/colors.css
@@ -155,6 +155,10 @@
   --color-sentiment-positive: rgb(76, 161, 90);
   --color-sentiment-positive--hover: rgb(90, 173, 104);
 
+  --color-sentiment-neutral--active: var(--color-product-deep-thought--active);
+  --color-sentiment-neutral: var(--color-product-deep-thought);
+  --color-sentiment-neutral--hover: var(--color-product-deep-thought--hover);
+
   --color-social-twitter: rgb(29, 161, 242);
   --color-social-facebook: rgb(59, 89, 152);
   --color-social-instagram: rgb(183, 71, 146);

--- a/packages/axiom-materials/src/colors.css
+++ b/packages/axiom-materials/src/colors.css
@@ -147,9 +147,9 @@
   --color-product-luna-dust: rgb(120, 144, 156);
   --color-product-luna-dust--hover: rgb(138, 158, 168);
 
-  --color-sentiment-neagtive--active: rgb(201, 58, 58);
-  --color-sentiment-neagtive: rgb(215, 74, 74);
-  --color-sentiment-neagtive--hover: rgb(227, 89, 89);
+  --color-sentiment-negative--active: rgb(201, 58, 58);
+  --color-sentiment-negative: rgb(215, 74, 74);
+  --color-sentiment-negative--hover: rgb(227, 89, 89);
 
   --color-sentiment-positive--active: rgb(62, 148, 76);
   --color-sentiment-positive: rgb(76, 161, 90);

--- a/packages/axiom-materials/src/colors.js
+++ b/packages/axiom-materials/src/colors.js
@@ -43,14 +43,6 @@ export const uiWhite = { r: 255, g: 255, b: 255 };
 
 export const uiHighlight = { r: 215, g: 255, b: 0 };
 
-export const sentimentPositiveActive = { r: 62, g: 148, b: 76 };
-export const sentimentPositive = { r: 76, g: 161, b: 90 };
-export const sentimentPositiveHover = { r: 90, g: 173, b: 104 };
-
-export const sentimentNegativeActive = { r: 201, g: 58, b: 58 };
-export const sentimentNegative = { r: 215, g: 74, b: 74 };
-export const sentimentNegativeHover = { r: 227, g: 89, b: 89 };
-
 export const productTinyClangerActive = { r: 232, g: 132, b: 166 };
 export const productTinyClanger = { r: 244, g: 152, b: 183 };
 export const productTinyClangerHover = { r: 255, g: 171, b: 199 };
@@ -126,6 +118,19 @@ export const productDeepThoughtHover = { r: 204, g: 204, b: 204 };
 export const productLunaDustActive = { r: 103, g: 129, b: 143 };
 export const productLunaDust = { r: 120, g: 144, b: 156 };
 export const productLunaDustHover = { r: 138, g: 158, b: 168 };
+
+export const sentimentPositiveActive = { r: 62, g: 148, b: 76 };
+export const sentimentPositive = { r: 76, g: 161, b: 90 };
+export const sentimentPositiveHover = { r: 90, g: 173, b: 104 };
+
+export const sentimentNegativeActive = { r: 201, g: 58, b: 58 };
+export const sentimentNegative = { r: 215, g: 74, b: 74 };
+export const sentimentNegativeHover = { r: 227, g: 89, b: 89 };
+
+export const sentimentNeutralActive = productDeepThoughtActive;
+export const sentimentNeutral = productDeepThought;
+export const sentimentNeutralHover = productDeepThoughtHover;
+
 
 export const socialTwitter = { r: 29, g: 161, b: 242 };
 export const socialFacebook = { r: 59, g: 89, b: 152 };

--- a/site/components/Documentation/Resources/Materials/Colors.js
+++ b/site/components/Documentation/Resources/Materials/Colors.js
@@ -94,6 +94,12 @@ export default class Documentation extends Component {
             <ColorDot name="Default" rgb={ colors.sentimentNegative } />
             <ColorDot name="Hover" rgb={ colors.sentimentNegativeHover } />
           </ColorSet>
+
+          <ColorSet name="Neutral">
+            <ColorDot name="Active" rgb={ colors.sentimentNeutralActive } />
+            <ColorDot name="Default" rgb={ colors.sentimentNeutral } />
+            <ColorDot name="Hover" rgb={ colors.sentimentNeutralHover } />
+          </ColorSet>
         </ColorGrid>
 
         <ColorGrid name="Product Colours">


### PR DESCRIPTION
### Allows sentiment colors in the BarChart

- fixed the typo ` --color-sentiment-neagtive` and marked it as a fix, as I didn't see it anywhere used on github
- Added the color `sentiment-neutral` as specified by @lilybrandwatch
- addes support for  sentiment colors for `Bar` and `DataPoint` components

![image](https://user-images.githubusercontent.com/111471/38079904-5d604cd4-3340-11e8-9e69-51bea31181cf.png)
