### PR TITLE
chore(tests): Always run tests in same timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "build:packages": "NODE_ENV=production BABEL_ENV=production bash ./scripts/build_packages.sh",
     "build:site": "NODE_ENV=production BABEL_ENV=static webpack --config webpack.static.config.js",
     "ci:setup": "NODE_ENV=production BABEL_ENV=production bash ./scripts/ci_setup.sh",
-    "ci:test": "jest ./packages/**/dist --config .jest.ci.json",
+    "ci:test": "TZ=utc jest ./packages/**/dist --config .jest.ci.json",
     "lint": "yarn run lint:js && yarn run lint:css",
     "lint:css": "stylelint 'packages/**/*.css' 'site/**/*.css'",
     "lint:js": "eslint --config .eslintrc packages site",
@@ -12,7 +12,7 @@
     "publish:packages": "bash ./scripts/publish_packages.sh",
     "publish:site": "bash ./scripts/publish_site.sh",
     "start": "bash ./scripts/start_development.sh",
-    "test": "BABEL_ENV=test jest ./packages --config .jest.json"
+    "test": "TZ=utc BABEL_ENV=test jest ./packages --config .jest.json"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
When I tried to run all tests locally, some of the tests were failing for me because of different timezones. This PR always sets the same timezone for testing. I am not sure if this is the cleanest solution, but it works.