### PR TITLE
fix(axisUtils): when upper and lower are equal return no labels

### DIFF
--- a/packages/axiom-charts/src/utils/axisUtils.js
+++ b/packages/axiom-charts/src/utils/axisUtils.js
@@ -7,6 +7,11 @@ export function getEquallyDistributedAxisLabels({
     tickCount = DEFAULT_TICK_COUNT,
     labelFormatter = v => v,
 }) {
+
+  if (lower === upper) {
+    return [];
+  }
+
   const finalTickCount = Math.max(MIN_TICK_COUNT, tickCount);
   const tickSize = (upper - lower) / (finalTickCount - 1);
   const ticks = [];

--- a/packages/axiom-charts/src/utils/axisUtils.test.js
+++ b/packages/axiom-charts/src/utils/axisUtils.test.js
@@ -18,6 +18,23 @@ describe('getEquallyDistributedAxisLabels', () => {
     expect(xAxisLabels).toMatchSnapshot();
   });
 
+  it('returns no labels when lower and upper are equal', () => {
+    expect(getEquallyDistributedAxisLabels({
+      lower: 0,
+      upper: 0,
+    })).toEqual([]);
+
+    expect(getEquallyDistributedAxisLabels({
+      lower: 1,
+      upper: 1,
+    })).toEqual([]);
+
+    expect(getEquallyDistributedAxisLabels({
+      lower: -100,
+      upper: -100,
+    })).toEqual([]);
+  });
+
   it('creates equal labels when lower 0, upper 10k, tickCount 6', () => {
     const xAxisLabels = getEquallyDistributedAxisLabels({
       lower: 0,


### PR DESCRIPTION
This guards against getting duplicate axis labels, of e.g. [0, 0, 0] for e.g. 

```js
axisUtils.getEquallyDistributedAxisLabels({upper=0, lower=0})
```

In case upper and lower are equal, just return no labels at all.

This currently causes React to loose track of the labels, as it sets a `key` of the label [here](https://github.com/BrandwatchLtd/axiom/blob/ec6eb66314f2014337318476b8308f09a1a9e99d/packages/axiom-charts/src/ChartTable/ChartTableRows.js#L66). This should probably be fixed separately as well. 