### PR TITLE
fix(Position): Reduces offset when arrow is not used

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -4,7 +4,6 @@
    * the pre-rotated square we use `Math.sqrt((1.5rem**2)/2)`
    */
   --cmp-context-tip-size: 1.0606601717798212rem;
-  --cmp-context-tip-edge-to-edge: 1.5rem;
   --cmp-context-tip-space: calc(var(--spacing-grid-size) * 2);
   --cmp-context-padding-small: calc(var(--spacing-grid-size) * 4);
   --cmp-context-padding-large: calc(var(--spacing-grid-size) * 6);

--- a/packages/axiom-components/src/Dropdown/Dropdown.js
+++ b/packages/axiom-components/src/Dropdown/Dropdown.js
@@ -18,6 +18,8 @@ export default class Dropdown extends Component {
      * Adds control to enable or disable showing the DropdownSource
      */
     enabled: PropTypes.bool,
+    /** Controls the starting offset of the content */
+    offset: PropTypes.oneOf(['start', 'middle', 'end']),
     /**
      * Invoked when the Dropdown is closed.
      */
@@ -80,13 +82,14 @@ export default class Dropdown extends Component {
   }
 
   render() {
-    const { children, position, ...rest } = this.props;
+    const { children, offset, position, ...rest } = this.props;
     const { isVisible } = this.state;
 
     return (
       <Position
           { ...rest }
           isVisible={ isVisible }
+          offset={ offset }
           onMaskClick={ () => this.close() }
           position={ position }>
         <PositionTarget>{ findComponent(children, DropdownTargetRef) }</PositionTarget>

--- a/packages/axiom-components/src/Position/Position.css
+++ b/packages/axiom-components/src/Position/Position.css
@@ -1,6 +1,10 @@
 .ax-position {
-  margin: calc(var(--cmp-context-tip-edge-to-edge) * 0.5);
+  margin: calc(var(--spacing-grid-size--x1) * 0.5);
   z-index: var(--z-index-position);
+}
+
+.ax-position--arrow {
+  margin: calc((var(--cmp-context-tip-edge-to-edge) * 0.5) + var(--spacing-grid-size--x1));
 }
 
 .ax-position__mask {

--- a/packages/axiom-components/src/Position/Position.js
+++ b/packages/axiom-components/src/Position/Position.js
@@ -3,6 +3,7 @@ import React, { Component, cloneElement } from 'react';
 import ReactDOM from 'react-dom';
 import popperJS from 'popper.js';
 import omit from 'lodash.omit';
+import classnames from 'classnames';
 import { findComponent } from '@brandwatch/axiom-utils';
 import Portal from '../Portal/Portal';
 import { PositionSourceRef } from './PositionSource';
@@ -156,6 +157,11 @@ export default class Position extends Component {
     const { children, enabled, isVisible, onMaskClick, showArrow, ...rest } = this.props;
     const { placement } = this.state;
     const [ position ] = placementToPosition(placement);
+
+    const classes = classnames('ax-position', {
+      'ax-position--arrow': showArrow,
+    });
+
     const props = omit(rest, [
       'flip',
       'offset',
@@ -174,7 +180,7 @@ export default class Position extends Component {
               <div className="ax-position__mask" onClick={ onMaskClick } />
             ) }
 
-            <div className="ax-position" ref={ (el) => this._content = el }>
+            <div className={ classes } ref={ (el) => this._content = el }>
               {
                 cloneElement(findComponent(children, PositionSourceRef), {
                   arrowRef: showArrow

--- a/packages/axiom-materials/src/sizing.css
+++ b/packages/axiom-materials/src/sizing.css
@@ -43,7 +43,7 @@
   --drop-shadow-elevation--x2: 0 0.25rem 0.5625rem 0;
 
   /**
-   * Chart variables.
+   * Shared chart variables.
    *
    *  [1] Needed to normalise bar widths. However
    *      this is not in relation to anything so
@@ -63,5 +63,10 @@
   --cmp-benchmark-line-height: var(--cmp-dot-plot-diameter);
 
   --cmp-chart-overflow-space: calc(var(--cmp-chart-label-width) + var(--cmp-dot-plot-radius));
+
+  /**
+   * Shared component variables.
+   */
+  --cmp-context-tip-edge-to-edge: 1.5rem;
 }
 /* stylelint-enable */


### PR DESCRIPTION
Also fixes an issue where preprocessing (and not preserving) CSS custom properties would cause the context components to be inset by the size of the arrow. 