### PR TITLE
feat(charts): add support for social colors

### DIFF
--- a/packages/axiom-charts/src/Bar/Bar.css
+++ b/packages/axiom-charts/src/Bar/Bar.css
@@ -52,6 +52,9 @@
   &.ax-bars__bar-rect--sentiment-positive { background-color: var(--color-sentiment-positive); }
   &.ax-bars__bar-rect--sentiment-negative { background-color: var(--color-sentiment-negative); }
   &.ax-bars__bar-rect--sentiment-neutral { background-color: var(--color-sentiment-neutral); }
+  &.ax-bars__bar-rect--social-twitter { background-color: var(--color-social-twitter); }
+  &.ax-bars__bar-rect--social-facebook { background-color: var(--color-social-facebook); }
+  &.ax-bars__bar-rect--social-instagram { background-color: var(--color-social-instagram); }
 }
 
 .ax-bars__bar--clickable {
@@ -170,6 +173,21 @@
     &.ax-bars__bar-rect--sentiment-neutral {
       &:hover { background-color: var(--color-sentiment-neutral--hover); }
       &:active { background-color: var(--color-sentiment-neutral--active); }
+    }
+
+    &.ax-bars__bar-rect--social-twitter {
+      &:hover { background-color: var(--color-social-twitter--hover); }
+      &:active { background-color: var(--color-social-twitter--active); }
+    }
+
+    &.ax-bars__bar-rect--social-facebook {
+      &:hover { background-color: var(--color-social-facebook--hover); }
+      &:active { background-color: var(--color-social-facebook--active); }
+    }
+
+    &.ax-bars__bar-rect--social-instagram {
+      &:hover { background-color: var(--color-social-instagram--hover); }
+      &:active { background-color: var(--color-social-instagram--active); }
     }
   }
 }

--- a/packages/axiom-charts/src/Bar/Bar.js
+++ b/packages/axiom-charts/src/Bar/Bar.js
@@ -30,6 +30,9 @@ export default class Bar extends Component {
       'sentiment-positive',
       'sentiment-negative',
       'sentiment-neutral',
+      'social-twitter',
+      'social-facebook',
+      'social-instagram',
     ]).isRequired,
     /** When true the bar is faded */
     isFaded: PropTypes.bool,

--- a/packages/axiom-charts/src/DataPoint/DataPoint.js
+++ b/packages/axiom-charts/src/DataPoint/DataPoint.js
@@ -31,6 +31,9 @@ export default class DataPoint extends Component {
       'sentiment-positive',
       'sentiment-negative',
       'sentiment-neutral',
+      'social-twitter',
+      'social-facebook',
+      'social-instagram',
     ]).isRequired,
     /** SKIP */
     r: PropTypes.number,

--- a/packages/axiom-charts/src/DataPoint/DataPoints.css
+++ b/packages/axiom-charts/src/DataPoint/DataPoints.css
@@ -41,6 +41,9 @@
 .ax-data-point--sentiment-positive { color: var(--color-sentiment-positive); }
 .ax-data-point--sentiment-negative { color: var(--color-sentiment-negative); }
 .ax-data-point--sentiment-neutral { color: var(--color-sentiment-neutral); }
+.ax-data-point--social-twitter { color: var(--color-social-twitter); }
+.ax-data-point--social-facebook { color: var(--color-social-facebook); }
+.ax-data-point--social-instagram { color: var(--color-social-instagram); }
 
 .ax-data-points--clickable {
   cursor: pointer;
@@ -68,6 +71,9 @@
     & .ax-data-point--sentiment-positive { color: var(--color-sentiment-positive--hover); }
     & .ax-data-point--sentiment-negative { color: var(--color-sentiment-negative--hover); }
     & .ax-data-point--sentiment-neutral { color: var(--color-sentiment-neutral--hover); }
+    & .ax-data-point--social-twitter { color: var(--color-social-twitter--hover); }
+    & .ax-data-point--social-facebook { color: var(--color-social-facebook--hover); }
+    & .ax-data-point--social-instagram { color: var(--color-social-instagram--hover); }
   }
 
   &:active {
@@ -93,5 +99,8 @@
     & .ax-data-point--sentiment-positive { color: var(--color-sentiment-positive--active); }
     & .ax-data-point--sentiment-negative { color: var(--color-sentiment-negative--active); }
     & .ax-data-point--sentiment-neutral { color: var(--color-sentiment-neutral--active); }
+    & .ax-data-point--social-twitter { color: var(--color-social-twitter--active); }
+    & .ax-data-point--social-facebook { color: var(--color-social-facebook--active); }
+    & .ax-data-point--social-instagram { color: var(--color-social-instagram--active); }
   }
 }

--- a/packages/axiom-charts/src/Line/Line.css
+++ b/packages/axiom-charts/src/Line/Line.css
@@ -80,3 +80,6 @@
 .ax-line--sentiment-positive { color: var(--color-sentiment-positive); }
 .ax-line--sentiment-negative { color: var(--color-sentiment-negative); }
 .ax-line--sentiment-neutral { color: var(--color-sentiment-neutral); }
+.ax-line--social-twitter { color: var(--color-social-twitter); }
+.ax-line--social-facebook { color: var(--color-social-facebook); }
+.ax-line--social-instagram { color: var(--color-social-instagram); }

--- a/packages/axiom-charts/src/Line/Line.js
+++ b/packages/axiom-charts/src/Line/Line.js
@@ -47,6 +47,9 @@ export default class Line extends Component {
       'sentiment-positive',
       'sentiment-negative',
       'sentiment-neutral',
+      'social-twitter',
+      'social-facebook',
+      'social-instagram',
     ]).isRequired,
     /** Dash length */
     dasharray: PropTypes.string,

--- a/packages/axiom-charts/src/Line/LinePoint.js
+++ b/packages/axiom-charts/src/Line/LinePoint.js
@@ -43,6 +43,9 @@ export default class LinePoint extends Component {
       'sentiment-positive',
       'sentiment-negative',
       'sentiment-neutral',
+      'social-twitter',
+      'social-facebook',
+      'social-instagram',
     ]).isRequired,
     /** Applies hover state, useful to retain hover styling. */
     hover: PropTypes.bool,


### PR DESCRIPTION
Adds support for social colors for all chart types.

![image](https://user-images.githubusercontent.com/111471/38483743-4fcfc2b0-3bd4-11e8-866f-42466bd863b4.png)
