### PR TITLE
fix(BarChart): fix stale label when using duplicate labels

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component, isValidElement } from 'react';
+import React, { Component } from 'react';
 import BarChartBars from './BarChartBars';
 import BarChartBenchmarkLine from './BarChartBenchmarkLine';
 import ChartKey from '../Chart/ChartKey';
@@ -171,7 +171,7 @@ export default class BarChart extends Component {
           { formattedData.map(({ values, label, benchmark }, index) =>
             <ChartTableRow
                 hover={ index === selectedIndex }
-                key={ isValidElement(label) ? index : label }>
+                key={ index }>
               <ChartTableLabel
                   textStrong={ index === selectedIndex }
                   width={ labelColumnWidth }>


### PR DESCRIPTION
When `data` for a BarChart contains multiple labels with the same name, one will remain in the chart after re-rendering different data.

This is due to the label being used as a `key`.

To fix this, we'll always use `index` as key, so React doesn't lose track of these elements.