### PR TITLE
Sticky Dropdown Header and Footer example. 

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -113,7 +113,7 @@
   left: 0;
 }
 
-.ax-context-content--scrollable {
+.ax-context-content--scrollable .ax-context-content__scroll {
   overflow-y: auto;
 }
 

--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -70,12 +70,24 @@
   position: relative;
 }
 
-.ax-context-content--padding-small {
-  padding: var(--cmp-context-padding-small);
+.ax-context-content--padding-horizontal-small {
+  padding-right: var(--cmp-context-padding-small);
+  padding-left: var(--cmp-context-padding-small);
 }
 
-.ax-context-content--padding-large {
-  padding: var(--cmp-context-padding-large);
+.ax-context-content--padding-horizontal-large {
+  padding-right: var(--cmp-context-padding-large);
+  padding-left: var(--cmp-context-padding-large);
+}
+
+.ax-context-content--padding-vertical-small {
+  padding-top: var(--cmp-context-padding-small);
+  padding-bottom: var(--cmp-context-padding-small);
+}
+
+.ax-context-content--padding-vertical-large {
+  padding-top: var(--cmp-context-padding-large);
+  padding-bottom: var(--cmp-context-padding-large);
 }
 
 .ax-context-content:not(:last-child)::after {
@@ -85,13 +97,13 @@
   border-bottom: var(--component-border-width) solid var(--color-theme-border);
 }
 
-.ax-context-content--padding-small::after {
+.ax-context-content--padding-horizontal-small::after {
   right: var(--cmp-context-padding-small);
   left: var(--cmp-context-padding-small);
 }
 
-.ax-context-content--padding-none::after,
-.ax-context-content--padding-large::after {
+.ax-context-content--padding-horizontal-none::after,
+.ax-context-content--padding-horizontal-large::after {
   right: var(--cmp-context-padding-large);
   left: var(--cmp-context-padding-large);
 }

--- a/packages/axiom-components/src/Context/Context.js
+++ b/packages/axiom-components/src/Context/Context.js
@@ -7,17 +7,11 @@ import './Context.css';
 /* eslint-disable react/no-find-dom-node */
 export default class Context extends Component {
   static propTypes = {
-    /** React reference function for the arrow element */
     arrowRef: PropTypes.func,
-    /** Content to be inserted in the contextual area */
     children: PropTypes.node,
-    /** Color of the Context */
     color: PropTypes.oneOf(['success', 'warning', 'error', 'info']),
-    /** Maximum height for the content area, exceeding this will make it scrollable */
     maxHeight: PropTypes.string,
-    /** Position of the content area relative to the arrow */
     position: PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
-    /** Total width of the component */
     width: PropTypes.string,
   };
 

--- a/packages/axiom-components/src/Context/ContextContent.js
+++ b/packages/axiom-components/src/Context/ContextContent.js
@@ -5,13 +5,10 @@ import Base from '../Base/Base';
 
 export default class ContextContent extends Component {
   static propTypes = {
-    /** Determines whether the separator below this context box should cut through the padding */
+    children: PropTypes.node,
     hasFullSeparator: PropTypes.bool,
-    /** Set height for the content area, box will remain at this height */
     height: PropTypes.string,
-    /** Maximum height for the content area, exceeding this will make it scrollable */
     maxHeight: PropTypes.string,
-    /** Padding size applied to the content area */
     padding: PropTypes.oneOf(['none', 'small', 'large']),
     paddingHorizontal: PropTypes.oneOf(['none', 'small', 'large']),
     paddingVertical: PropTypes.oneOf(['none', 'small', 'large']),

--- a/packages/axiom-components/src/Context/ContextContent.js
+++ b/packages/axiom-components/src/Context/ContextContent.js
@@ -21,6 +21,7 @@ export default class ContextContent extends Component {
 
   render() {
     const {
+      children,
       hasFullSeparator,
       height,
       maxHeight,
@@ -36,12 +37,16 @@ export default class ContextContent extends Component {
       `ax-context-content--padding-vertical-${paddingVertical}`,
       {
         'ax-context-content--full-separator': hasFullSeparator,
-        'ax-context-content--scrollable': maxHeight,
+        'ax-context-content--scrollable': height || maxHeight,
       }
     );
 
     return (
-      <Base { ...rest } className={ classes } style={ { height, maxHeight } } />
+      <Base { ...rest } className={ classes }>
+        <div className="ax-context-content__scroll" style={ { height, maxHeight } }>
+          { children }
+        </div>
+      </Base>
     );
   }
 }

--- a/packages/axiom-components/src/Context/ContextContent.js
+++ b/packages/axiom-components/src/Context/ContextContent.js
@@ -13,6 +13,8 @@ export default class ContextContent extends Component {
     maxHeight: PropTypes.string,
     /** Padding size applied to the content area */
     padding: PropTypes.oneOf(['none', 'small', 'large']),
+    paddingHorizontal: PropTypes.oneOf(['none', 'small', 'large']),
+    paddingVertical: PropTypes.oneOf(['none', 'small', 'large']),
   };
 
   static defaultProps = {
@@ -21,10 +23,20 @@ export default class ContextContent extends Component {
   };
 
   render() {
-    const { hasFullSeparator, height, maxHeight, padding, ...rest } = this.props;
+    const {
+      hasFullSeparator,
+      height,
+      maxHeight,
+      padding,
+      paddingHorizontal = padding,
+      paddingVertical = padding,
+      ...rest
+    } = this.props;
+
     const classes = classnames(
       'ax-context-content',
-      `ax-context-content--padding-${padding}`,
+      `ax-context-content--padding-horizontal-${paddingHorizontal}`,
+      `ax-context-content--padding-vertical-${paddingVertical}`,
       {
         'ax-context-content--full-separator': hasFullSeparator,
         'ax-context-content--scrollable': maxHeight,

--- a/packages/axiom-components/src/Context/ContextMenu.js
+++ b/packages/axiom-components/src/Context/ContextMenu.js
@@ -4,7 +4,6 @@ import ContextContent from './ContextContent';
 
 export default class ContextMenu extends Component {
   static propTypes = {
-    /** Content inserted into the menu, ideally ContextMenuItem */
     children: PropTypes.node,
   };
 

--- a/packages/axiom-components/src/Context/__snapshots__/ContextContent.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextContent.test.js.snap
@@ -2,98 +2,126 @@
 
 exports[`ContextContent renders with defaultProps 1`] = `
 <div
-  className="ax-context-content ax-context-content--padding-large"
-  style={
-    Object {
-      "height": undefined,
-      "maxHeight": undefined,
-    }
-  }
+  className="ax-context-content ax-context-content--padding-horizontal-large ax-context-content--padding-vertical-large"
 >
-  Lorem ipsum
+  <div
+    className="ax-context-content__scroll"
+    style={
+      Object {
+        "height": undefined,
+        "maxHeight": undefined,
+      }
+    }
+  >
+    Lorem ipsum
+  </div>
 </div>
 `;
 
 exports[`ContextContent renders with hasFullSeparator renders with the full-separator element modifier 1`] = `
 <div
-  className="ax-context-content ax-context-content--padding-large ax-context-content--full-separator"
-  style={
-    Object {
-      "height": undefined,
-      "maxHeight": undefined,
-    }
-  }
+  className="ax-context-content ax-context-content--padding-horizontal-large ax-context-content--padding-vertical-large ax-context-content--full-separator"
 >
-  Lorem ipsum
+  <div
+    className="ax-context-content__scroll"
+    style={
+      Object {
+        "height": undefined,
+        "maxHeight": undefined,
+      }
+    }
+  >
+    Lorem ipsum
+  </div>
 </div>
 `;
 
 exports[`ContextContent renders with height inserts an inline height style attribute 1`] = `
 <div
-  className="ax-context-content ax-context-content--padding-large"
-  style={
-    Object {
-      "height": "5rem",
-      "maxHeight": undefined,
-    }
-  }
+  className="ax-context-content ax-context-content--padding-horizontal-large ax-context-content--padding-vertical-large ax-context-content--scrollable"
 >
-  Lorem ipsum
+  <div
+    className="ax-context-content__scroll"
+    style={
+      Object {
+        "height": "5rem",
+        "maxHeight": undefined,
+      }
+    }
+  >
+    Lorem ipsum
+  </div>
 </div>
 `;
 
 exports[`ContextContent renders with maxHeight inserts an inline maxHeight style attribute 1`] = `
 <div
-  className="ax-context-content ax-context-content--padding-large ax-context-content--scrollable"
-  style={
-    Object {
-      "height": undefined,
-      "maxHeight": "5rem",
-    }
-  }
+  className="ax-context-content ax-context-content--padding-horizontal-large ax-context-content--padding-vertical-large ax-context-content--scrollable"
 >
-  Lorem ipsum
+  <div
+    className="ax-context-content__scroll"
+    style={
+      Object {
+        "height": undefined,
+        "maxHeight": "5rem",
+      }
+    }
+  >
+    Lorem ipsum
+  </div>
 </div>
 `;
 
 exports[`ContextContent renders with padding large 1`] = `
 <div
-  className="ax-context-content ax-context-content--padding-large"
-  style={
-    Object {
-      "height": undefined,
-      "maxHeight": undefined,
-    }
-  }
+  className="ax-context-content ax-context-content--padding-horizontal-large ax-context-content--padding-vertical-large"
 >
-  Lorem ipsum
+  <div
+    className="ax-context-content__scroll"
+    style={
+      Object {
+        "height": undefined,
+        "maxHeight": undefined,
+      }
+    }
+  >
+    Lorem ipsum
+  </div>
 </div>
 `;
 
 exports[`ContextContent renders with padding none 1`] = `
 <div
-  className="ax-context-content ax-context-content--padding-none"
-  style={
-    Object {
-      "height": undefined,
-      "maxHeight": undefined,
-    }
-  }
+  className="ax-context-content ax-context-content--padding-horizontal-none ax-context-content--padding-vertical-none"
 >
-  Lorem ipsum
+  <div
+    className="ax-context-content__scroll"
+    style={
+      Object {
+        "height": undefined,
+        "maxHeight": undefined,
+      }
+    }
+  >
+    Lorem ipsum
+  </div>
 </div>
 `;
 
 exports[`ContextContent renders with padding small 1`] = `
 <div
-  className="ax-context-content ax-context-content--padding-small"
-  style={
-    Object {
-      "height": undefined,
-      "maxHeight": undefined,
-    }
-  }
+  className="ax-context-content ax-context-content--padding-horizontal-small ax-context-content--padding-vertical-small"
 >
-  Lorem ipsum
+  <div
+    className="ax-context-content__scroll"
+    style={
+      Object {
+        "height": undefined,
+        "maxHeight": undefined,
+      }
+    }
+  >
+    Lorem ipsum
+  </div>
 </div>
 `;

--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
@@ -2,29 +2,33 @@
 
 exports[`ContextMenu renders with defaultProps 1`] = `
 <div
-  className="ax-context-content ax-context-content--padding-none"
-  style={
-    Object {
-      "height": undefined,
-      "maxHeight": undefined,
-    }
-  }
+  className="ax-context-content ax-context-content--padding-horizontal-none ax-context-content--padding-vertical-none"
 >
   <div
-    className="ax-context-menu"
+    className="ax-context-content__scroll"
+    style={
+      Object {
+        "height": undefined,
+        "maxHeight": undefined,
+      }
+    }
   >
-    <button
-      className="ax-context-menu__item"
-      data-ax-context-menu-item={true}
-      disabled={undefined}
-      onClick={undefined}
+    <div
+      className="ax-context-menu"
     >
-      <div
-        className="ax-context-menu__item-content"
+      <button
+        className="ax-context-menu__item"
+        data-ax-context-menu-item={true}
+        disabled={undefined}
+        onClick={undefined}
       >
-        Lorem ipsum
-      </div>
-    </button>
+        <div
+          className="ax-context-menu__item-content"
+        >
+          Lorem ipsum
+        </div>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/packages/axiom-components/src/Dropdown/DropdownContent.js
+++ b/packages/axiom-components/src/Dropdown/DropdownContent.js
@@ -1,7 +1,23 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ContextContent from '../Context/ContextContent';
 
 export default class DropdownContent extends Component {
+  static propTypes = {
+    /** Determines whether the separator below this context box should cut through the padding */
+    hasFullSeparator: PropTypes.bool,
+    /** Set height for the content area, box will remain at this height */
+    height: PropTypes.string,
+    /** Maximum height for the content area, exceeding this will make it scrollable */
+    maxHeight: PropTypes.string,
+    /** Padding size applied to the content area */
+    padding: PropTypes.oneOf(['none', 'small', 'large']),
+    /** Horizontal padding size applied to the content area */
+    paddingHorizontal: PropTypes.oneOf(['none', 'small', 'large']),
+    /** Vertical padding size applied to the content area */
+    paddingVertical: PropTypes.oneOf(['none', 'small', 'large']),
+  };
+
   render() {
     return (
       <ContextContent { ...this.props } />

--- a/packages/axiom-components/src/Dropdown/DropdownContext.js
+++ b/packages/axiom-components/src/Dropdown/DropdownContext.js
@@ -11,6 +11,27 @@ const isFocusableMenuItem = (element) =>
 
 /* eslint-disable react/no-find-dom-node */
 export default class DropdownContext extends Component {
+  static propTypes = {
+    /** React reference function for the arrow element */
+    arrowRef: PropTypes.func,
+    /** Content to be inserted in the contextual area */
+    children: PropTypes.node,
+    /** Color of the Context */
+    color: PropTypes.oneOf(['success', 'warning', 'error', 'info']),
+    /** Maximum height for the content area, exceeding this will make it scrollable */
+    maxHeight: PropTypes.string,
+    /** Position of the content area relative to the arrow */
+    position: PropTypes.oneOf(['top', 'bottom', 'right', 'left']),
+    /** Total width of the component */
+    width: PropTypes.string,
+  };
+
+  static defaultProps = {
+    maxHeight: '30rem',
+    position: 'top',
+    width: '14.5rem',
+  };
+
   static contextTypes = {
     closeDropdown: PropTypes.func.isRequired,
   };

--- a/packages/axiom-components/src/Dropdown/DropdownFooter.js
+++ b/packages/axiom-components/src/Dropdown/DropdownFooter.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react';
+import ContextContent from '../Context/ContextContent';
+
+export default class DropdownFooter extends Component {
+  render() {
+    return (
+      <ContextContent { ...this.props }
+          hasFullSeparator
+          paddingVertical="small" />
+    );
+  }
+}

--- a/packages/axiom-components/src/Dropdown/DropdownHeader.js
+++ b/packages/axiom-components/src/Dropdown/DropdownHeader.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react';
+import ContextContent from '../Context/ContextContent';
+
+export default class DropdownHeader extends Component {
+  render() {
+    return (
+      <ContextContent { ...this.props }
+          hasFullSeparator
+          paddingVertical="small" />
+    );
+  }
+}

--- a/packages/axiom-components/src/Dropdown/DropdownMenu.js
+++ b/packages/axiom-components/src/Dropdown/DropdownMenu.js
@@ -4,8 +4,8 @@ import ContextMenu from '../Context/ContextMenu';
 
 export default class DropdownMenu extends Component {
   static propTypes = {
+    /** DropdownMenuItems */
     children: PropTypes.node.isRequired,
-    index: PropTypes.string,
   };
 
   render() {

--- a/packages/axiom-components/src/Dropdown/DropdownMenuItem.js
+++ b/packages/axiom-components/src/Dropdown/DropdownMenuItem.js
@@ -5,8 +5,11 @@ import ContextMenuItem from '../Context/ContextMenuItem';
 
 export default class DropdownMenuItem extends Component {
   static propTypes = {
+    /** SKIP */
     children: PropTypes.node,
-    /**
+    /** Disabled interactions and applies styling */
+    disabled: PropTypes.bool,
+   /**
     * Whether the menu should stay open after being clicked.
     */
     keepOpen: PropTypes.bool,
@@ -17,6 +20,8 @@ export default class DropdownMenuItem extends Component {
     multiSelect: PropTypes.bool,
     /** Click handler  */
     onClick: PropTypes.func,
+    /** Provides indication that the menu item is selected */
+    selected: PropTypes.bool,
   };
 
   static contextTypes = {

--- a/packages/axiom-components/src/index.js
+++ b/packages/axiom-components/src/index.js
@@ -59,6 +59,8 @@ export { default as DockItem } from './Platform/DockItem';
 export { default as Dropdown } from './Dropdown/Dropdown';
 export { default as DropdownContent } from './Dropdown/DropdownContent';
 export { default as DropdownContext } from './Dropdown/DropdownContext';
+export { default as DropdownFooter } from './Dropdown/DropdownFooter';
+export { default as DropdownHeader } from './Dropdown/DropdownHeader';
 export { default as DropdownMenu } from './Dropdown/DropdownMenu';
 export { default as DropdownMenuItem } from './Dropdown/DropdownMenuItem';
 export { default as DropdownSource } from './Dropdown/DropdownSource';

--- a/site/components/Documentation/Resources/Components/Dropdown.js
+++ b/site/components/Documentation/Resources/Components/Dropdown.js
@@ -7,11 +7,16 @@ import {
   GridCell,
   Dropdown,
   DropdownContext,
+  DropdownFooter,
+  DropdownHeader,
   DropdownMenu,
   DropdownMenuItem,
   DropdownSource,
   DropdownTarget,
+  Icon,
+  IconButton,
   Link,
+  Paragraph,
   TextIcon,
   TextInput,
   TextInputIcon,
@@ -114,59 +119,141 @@ export default class Documentation extends Component {
           </GridCell>
         </Grid>
 
-        <DocumentationShowCase centered>
-          <Dropdown flip="mirror" showArrow={ false }>
-            <DropdownTarget>
-              <TextInput
-                  onChange={ () => {} }
-                  readOnly
-                  value={ multiSelection.join(', ') }>
-                <TextInputIcon name="chevron-down" />
-              </TextInput>
-            </DropdownTarget>
+        <Grid>
+          <GridCell>
+            <DocumentationShowCase centered>
+              <Dropdown flip="mirror" showArrow={ false }>
+                <DropdownTarget>
+                  <TextInput
+                      onChange={ () => {} }
+                      readOnly
+                      value={ multiSelection.join(', ') }>
+                    <TextInputIcon name="chevron-down" />
+                  </TextInput>
+                </DropdownTarget>
 
-            <DropdownSource>
-              <DropdownContext>
-                <DropdownMenu>
-                  <DropdownMenuItem
-                      multiSelect
-                      onClick={ () => this.handleMultiSelection('Option 1') }
-                      selected={ multiSelection.indexOf('Option 1') >= 0 }>
-                    Option 1
-                  </DropdownMenuItem>
+                <DropdownSource>
+                  <DropdownContext>
+                    <DropdownMenu>
+                      <DropdownMenuItem
+                          multiSelect
+                          onClick={ () => this.handleMultiSelection('Option 1') }
+                          selected={ multiSelection.indexOf('Option 1') >= 0 }>
+                        Option 1
+                      </DropdownMenuItem>
 
-                  <DropdownMenuItem
-                      multiSelect
-                      onClick={ () => this.handleMultiSelection('Option 2') }
-                      selected={ multiSelection.indexOf('Option 2') >= 0 }>
-                    Option 2
-                  </DropdownMenuItem>
-                </DropdownMenu>
+                      <DropdownMenuItem
+                          multiSelect
+                          onClick={ () => this.handleMultiSelection('Option 2') }
+                          selected={ multiSelection.indexOf('Option 2') >= 0 }>
+                        Option 2
+                      </DropdownMenuItem>
+                    </DropdownMenu>
 
-                <DropdownMenu>
-                  <DropdownMenuItem
-                      disabled
-                      multiSelect
-                      onClick={ () => this.handleMultiSelection('Option 3') }
-                      selected={ multiSelection.indexOf('Option 3') >= 0 }>
-                    Option 3
-                  </DropdownMenuItem>
+                    <DropdownMenu>
+                      <DropdownMenuItem
+                          disabled
+                          multiSelect
+                          onClick={ () => this.handleMultiSelection('Option 3') }
+                          selected={ multiSelection.indexOf('Option 3') >= 0 }>
+                        Option 3
+                      </DropdownMenuItem>
 
-                  <DropdownMenuItem
-                      multiSelect
-                      onClick={ () => this.handleMultiSelection('Option 4') }
-                      selected={ multiSelection.indexOf('Option 4') >= 0 }>
-                    Option 4
-                  </DropdownMenuItem>
-                </DropdownMenu>
-              </DropdownContext>
-            </DropdownSource>
-          </Dropdown>
-        </DocumentationShowCase>
+                      <DropdownMenuItem
+                          multiSelect
+                          onClick={ () => this.handleMultiSelection('Option 4') }
+                          selected={ multiSelection.indexOf('Option 4') >= 0 }>
+                        Option 4
+                      </DropdownMenuItem>
+                    </DropdownMenu>
+                  </DropdownContext>
+                </DropdownSource>
+              </Dropdown>
+            </DocumentationShowCase>
+          </GridCell>
+
+          <GridCell>
+            <DocumentationShowCase centered>
+              <Dropdown flip="mirror">
+                <DropdownTarget>
+                  <IconButton name="ellipsis" />
+                </DropdownTarget>
+
+                <DropdownSource>
+                  <DropdownContext width="16rem">
+                    <DropdownHeader>
+                      <Grid gutters="tiny" responsive={ false } verticalAlign="middle">
+                        <GridCell none>
+                          <Link style="body">
+                            <Icon name="chevron-left" />
+                          </Link>
+                        </GridCell>
+
+                        <GridCell>
+                          <Paragraph
+                              textCase="upper"
+                              textCenter
+                              textColor="subtle"
+                              textEllipsis
+                              textSize="small">
+                            Lorem Ipsum
+                          </Paragraph>
+                        </GridCell>
+
+                        <GridCell cloak none>
+                          <Link style="body">
+                            <Icon name="chevron-left" />
+                          </Link>
+                        </GridCell>
+                      </Grid>
+                    </DropdownHeader>
+
+                    <DropdownHeader>
+                      <TextInput placeholder="Text Input">
+                        <TextInputIcon
+                            align="left"
+                            name="magnify-glass" />
+                      </TextInput>
+                    </DropdownHeader>
+
+                    <DropdownMenu hasFullSeparator maxHeight="15rem">
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                      <DropdownMenuItem multiSelect>Lorem ipsum</DropdownMenuItem>
+                    </DropdownMenu>
+
+                    <DropdownFooter>
+                      <ButtonGroup textRight>
+                        <Button size="small" style="secondary">Cancel</Button>
+                        <Button size="small">Confirm</Button>
+                      </ButtonGroup>
+                    </DropdownFooter>
+                  </DropdownContext>
+                </DropdownSource>
+              </Dropdown>
+            </DocumentationShowCase>
+          </GridCell>
+        </Grid>
 
         <DocumentationApi components={ [
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Dropdown/Dropdown'),
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Dropdown/DropdownContent'),
+          require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Dropdown/DropdownContext'),
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Dropdown/DropdownMenu'),
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Dropdown/DropdownMenuItem'),
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Dropdown/DropdownSource'),


### PR DESCRIPTION
This was technically already kind of possible, except for:

* a bug with the placement of the separator on a scrollable list (6a95a67)
* compact content area with smaller vertical padding (055f3d8)

I also added an alias component for `DropdownHeader` and `DropdownFooter` (e517994), although these aren't really needed so happy to drop off if anybody thinks they are just noise. 

I also moved over the propType docs to Dropdown (5f514a4) , because the lower level Context components do not appear in the Style Guide. 

![](https://user-images.githubusercontent.com/7130591/38942442-af749566-4326-11e8-85b5-dd6a30011bfa.png)

