### PR TITLE
feat(TableRow): adds a hasBorder property to TableRow and TableCell

### DIFF
--- a/packages/axiom-components/src/Table/Table.css
+++ b/packages/axiom-components/src/Table/Table.css
@@ -12,7 +12,12 @@
   transition-timing-function: var(--transition-function);
 }
 
+.ax-table__row--borderless .ax-table__cell {
+  border-top-width: 0;
+}
+
 .ax-table__row:first-child .ax-table__cell {
+  border-top-width: var(--component-border-width-medium);
   border-top-style: solid;
 }
 

--- a/packages/axiom-components/src/Table/TableRow.js
+++ b/packages/axiom-components/src/Table/TableRow.js
@@ -5,6 +5,8 @@ import Base from '../Base/Base';
 
 export default class TableRow extends Component {
   static propTypes = {
+    /** Specifies whether or not the row should have borders */
+    borderless: PropTypes.bool,
     /** TableCells */
     children: PropTypes.node,
     /** Apply hover styling */
@@ -14,12 +16,14 @@ export default class TableRow extends Component {
   render() {
     const {
       children,
+      borderless,
       hover,
       ...rest
     } = this.props;
 
     const className = classnames('ax-table__row', {
       'ax-table__row--hover': hover,
+      'ax-table__row--borderless': borderless,
     });
 
     return (

--- a/packages/axiom-components/src/Table/TableRow.test.js
+++ b/packages/axiom-components/src/Table/TableRow.test.js
@@ -3,18 +3,24 @@ import renderer from 'react-test-renderer';
 import TableCell from './TableCell';
 import TableRow from './TableRow';
 
-const getComponent = () =>
+const getComponent = (props = {}) =>
   renderer.create(
-    <TableRow>
+    <TableRow { ...props }>
       <TableCell>
         123456
       </TableCell>
     </TableRow>
   );
 
-describe('TableHead', () => {
+describe('TableRow', () => {
   it('renders with defaultProps', () => {
     const component = getComponent();
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders without borders', () => {
+    const component = getComponent({ borderless: true });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/axiom-components/src/Table/__snapshots__/TableRow.test.js.snap
+++ b/packages/axiom-components/src/Table/__snapshots__/TableRow.test.js.snap
@@ -1,8 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableHead renders with defaultProps 1`] = `
+exports[`TableRow renders with defaultProps 1`] = `
 <tr
   className="ax-table__row"
+>
+  <td
+    className="ax-table__cell ax-table__cell--align-left"
+  >
+    123456
+  </td>
+</tr>
+`;
+
+exports[`TableRow renders without borders 1`] = `
+<tr
+  className="ax-table__row ax-table__row--borderless"
 >
   <td
     className="ax-table__cell ax-table__cell--align-left"


### PR DESCRIPTION
Adds a `hasBorder` property to TableRow and TableCell to allow for borderless rows and cells.