### PR TITLE
Fix redundant separator after submenu

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -96,25 +96,25 @@
   padding-bottom: var(--cmp-context-padding-large);
 }
 
-.ax-context-content:not(:last-child)::after {
+.ax-context-content + .ax-context-content::before {
   content: '';
   position: absolute;
-  bottom: 0;
-  border-bottom: var(--component-border-width) solid var(--color-theme-border);
+  top: 0;
+  border-top: var(--component-border-width) solid var(--color-theme-border);
 }
 
-.ax-context-content--padding-horizontal-small::after {
+.ax-context-content--padding-horizontal-small::before {
   right: var(--cmp-context-padding-small);
   left: var(--cmp-context-padding-small);
 }
 
-.ax-context-content--padding-horizontal-none::after,
-.ax-context-content--padding-horizontal-large::after {
+.ax-context-content--padding-horizontal-none::before,
+.ax-context-content--padding-horizontal-large::before {
   right: var(--cmp-context-padding-large);
   left: var(--cmp-context-padding-large);
 }
 
-.ax-context-content--full-separator::after {
+.ax-context-content--full-separator::before {
   right: 0;
   left: 0;
 }

--- a/site/components/Documentation/Resources/Components/Dropdown.js
+++ b/site/components/Documentation/Resources/Components/Dropdown.js
@@ -162,9 +162,7 @@ export default class Documentation extends Component {
                           Option 2.2
                         </DropdownMenuItem>
                       </DropdownMenu>
-                    </DropdownMenu>
 
-                    <DropdownMenu>
                       <DropdownMenuItem
                           disabled
                           multiSelect


### PR DESCRIPTION
[Deploy Link](https://5ae98e0bc965926325846456--youthful-albattani-41ebb2.netlify.com/docs/packages/axiom-components/dropdown)

As discussed with @HHogg - this PR fixes separator lines being drawn after submenus in Dropdowns.

Also fixed the example for dropdowns, where the submenu was wrapped in an own `DropdownMenu`.

### Before:

![image](https://user-images.githubusercontent.com/111471/39517521-56d7def6-4e00-11e8-91ed-20484c265033.png)

### After: 

![image](https://user-images.githubusercontent.com/111471/39517542-68de9e78-4e00-11e8-9778-98e73afb22dc.png)

