### PR TITLE
fix(Checkbox): ensure Checkbox is always a controlled component

### DIFF
--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
@@ -80,7 +80,7 @@ exports[`ContextMenuItem renders with multiSelect 1`] = `
       title={undefined}
     >
       <input
-        checked={undefined}
+        checked={false}
         className="ax-checkbox__input"
         disabled={undefined}
         name={undefined}
@@ -153,7 +153,7 @@ exports[`ContextMenuItem renders with multiSelect and title 1`] = `
       title={undefined}
     >
       <input
-        checked={undefined}
+        checked={false}
         className="ax-checkbox__input"
         disabled={undefined}
         name={undefined}

--- a/packages/axiom-components/src/Form/CheckBox.js
+++ b/packages/axiom-components/src/Form/CheckBox.js
@@ -50,7 +50,7 @@ export default class CheckBox extends Component {
         { (isValid) =>
           <ChedioButtox
               { ...rest }
-              checked={ checked || indeterminate }
+              checked={ !!(checked || indeterminate) }
               className="ax-checkbox"
               disabled={ disabled }
               indeterminate={ indeterminate && !checked }

--- a/packages/axiom-components/src/Form/__snapshots__/CheckBox.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/CheckBox.test.js.snap
@@ -7,7 +7,7 @@ exports[`CheckBox renders with defaultProps 1`] = `
   title={undefined}
 >
   <input
-    checked={undefined}
+    checked={false}
     className="ax-checkbox__input"
     disabled={undefined}
     name={undefined}
@@ -31,7 +31,7 @@ exports[`CheckBox renders with disabled 1`] = `
   title={undefined}
 >
   <input
-    checked={undefined}
+    checked={false}
     className="ax-checkbox__input"
     disabled={true}
     name={undefined}
@@ -103,7 +103,7 @@ exports[`CheckBox renders with invalid 1`] = `
   title={undefined}
 >
   <input
-    checked={undefined}
+    checked={false}
     className="ax-checkbox__input"
     disabled={undefined}
     name={undefined}

--- a/packages/axiom-components/src/Form/__snapshots__/CheckBoxGroup.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/CheckBoxGroup.test.js.snap
@@ -10,7 +10,7 @@ exports[`CheckBox renders with defaultProps 1`] = `
     title={undefined}
   >
     <input
-      checked={undefined}
+      checked={false}
       className="ax-checkbox__input"
       disabled={undefined}
       name={undefined}


### PR DESCRIPTION
Encountered a weird behaviour with a selected `DropdownMenuItem` on the benchmark component , where the selected state was not updated on re-rendering. 

React did spit out

> Warning: A component is changing a controlled input of type checkbox to be uncontrolled. Input elements should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components

Digging into this, it turned out that [this](https://github.com/BrandwatchLtd/axiom/blob/master/packages/axiom-components/src/Form/CheckBox.js#L53) was causing the issue. If `indeterminate` was `undefined`, `checked` was undefined, hence it was switching between controlled and uncontrolled input.

This PR fixes this.