### PR TITLE
fix(BarChart): Do not highlight all bars with same color if there is only one bar per row

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -60,6 +60,8 @@ export default class BarChart extends Component {
     showBarLabel: PropTypes.bool,
     /** Control for toggling visibility of the key */
     showKey: PropTypes.bool,
+    /** If set to true each color will be handled individually when hovering */
+    singleSelect: PropTypes.bool,
     /** Thickness of the bars */
     size: PropTypes.string,
     /** Upper value of the data displayed on the chart */
@@ -139,6 +141,7 @@ export default class BarChart extends Component {
       rowSpace,
       showBarLabel,
       showKey,
+      singleSelect,
       size,
       upper = dataUpper,
       xAxisLabels,
@@ -187,6 +190,8 @@ export default class BarChart extends Component {
                     fadeBenchmarkLine={ selectedIndex !== null }
                     hideBars={ isMultipleValuesData && selectedIndex !== null && selectedIndex !== index }
                     hoverColor={ selectedColor }
+                    hoverIndex={ selectedIndex }
+                    index={ index }
                     isHovered={ isMultipleValuesData && index === selectedIndex }
                     label={ label }
                     lower={ finalLower }
@@ -195,6 +200,7 @@ export default class BarChart extends Component {
                     onMouseEnter={ (color) => this.handleMouseEnter(index, color) }
                     onMouseLeave={ () => this.handleMouseLeave() }
                     showBarLabel={ showBarLabel }
+                    singleSelect={ singleSelect }
                     size={ size }
                     upper={ finalUpper }
                     values={ values } />

--- a/packages/axiom-charts/src/BarChart/BarChartBars.js
+++ b/packages/axiom-charts/src/BarChart/BarChartBars.js
@@ -18,6 +18,8 @@ export default class BarChartBars extends Component {
     fadeBenchmarkLine: PropTypes.bool.isRequired,
     hideBars: PropTypes.bool.isRequired,
     hoverColor: PropTypes.string,
+    hoverIndex: PropTypes.number,
+    index: PropTypes.number,
     isHovered: PropTypes.bool.isRequired,
     label: PropTypes.node.isRequired,
     lower: PropTypes.number,
@@ -26,6 +28,7 @@ export default class BarChartBars extends Component {
     onMouseEnter: PropTypes.func.isRequired,
     onMouseLeave: PropTypes.func.isRequired,
     showBarLabel: PropTypes.bool,
+    singleSelect: PropTypes.bool,
     size: PropTypes.string,
     upper: PropTypes.number,
     values: PropTypes.array.isRequired,
@@ -41,10 +44,13 @@ export default class BarChartBars extends Component {
       fadeBenchmarkLine,
       hideBars,
       hoverColor,
+      hoverIndex,
       isHovered,
+      index,
       label,
       lower,
       showBarLabel,
+      singleSelect,
       size,
       upper,
       values,
@@ -67,7 +73,10 @@ export default class BarChartBars extends Component {
       <div className={ classes }>
         <Bars direction="right">
           { values.map(({ color, value }) => {
-            const isFaded = hoverColor && color !== hoverColor;
+            const isFaded = singleSelect
+              ? Number.isInteger(hoverIndex) && hoverIndex !== index
+              : hoverColor && color !== hoverColor;
+
             const percent = ((value - lower) / (upper - lower)) * 100;
             const labelClasses = classnames('ax-bar-chart__bar-label', {
               'ax-bar-chart__bar-label--hidden': !(showBarLabel || color === hoverColor),


### PR DESCRIPTION
Right now if you only use one bar per row, and you hover a row, all rows with the same color are highlighted which in that case is not the desired result (we just want to highlight the actual hovered row).