### PR TITLE
feat(BarChart) Add option to fade out a bar

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -168,36 +168,39 @@ export default class BarChart extends Component {
             xAxisLabels={ xAxisLabels }
             zoom={ zoom }
             zoomTo={ zoom ? zoomTo : undefined }>
-          { formattedData.map(({ values, label, benchmark }, index) =>
+          { formattedData.map(({ values, label, benchmark, isFaded }, index) =>
             <ChartTableRow
                 hover={ index === selectedIndex }
                 key={ index }>
               <ChartTableLabel
+                  isFaded={ isFaded }
                   textStrong={ index === selectedIndex }
                   width={ labelColumnWidth }>
                 { label }
               </ChartTableLabel>
               <ChartTableVisual>
-                <BarChartBars
-                    DropdownContext={ DropdownContext }
-                    barLabel={ barLabel }
-                    benchmark={ benchmark }
-                    benchmarkHeight={ rowSpace }
-                    data={ data[index] }
-                    fadeBenchmarkLine={ selectedIndex !== null }
-                    hideBars={ isMultipleValuesData && selectedIndex !== null && selectedIndex !== index }
-                    hoverColor={ selectedColor }
-                    isHovered={ isMultipleValuesData && index === selectedIndex }
-                    label={ label }
-                    lower={ finalLower }
-                    onDropdownClose={ () => this.handleDropdonClose() }
-                    onDropdownOpen={ (color) => this.handleDropdonOpen(index, color) }
-                    onMouseEnter={ (color) => this.handleMouseEnter(index, color) }
-                    onMouseLeave={ () => this.handleMouseLeave() }
-                    showBarLabel={ showBarLabel }
-                    size={ size }
-                    upper={ finalUpper }
-                    values={ values } />
+                { !isFaded &&
+                  <BarChartBars
+                      DropdownContext={ DropdownContext }
+                      barLabel={ barLabel }
+                      benchmark={ benchmark }
+                      benchmarkHeight={ rowSpace }
+                      data={ data[index] }
+                      fadeBenchmarkLine={ selectedIndex !== null }
+                      hideBars={ isMultipleValuesData && selectedIndex !== null && selectedIndex !== index }
+                      hoverColor={ selectedColor }
+                      isHovered={ isMultipleValuesData && index === selectedIndex }
+                      label={ label }
+                      lower={ finalLower }
+                      onDropdownClose={ () => this.handleDropdonClose() }
+                      onDropdownOpen={ (color) => this.handleDropdonOpen(index, color) }
+                      onMouseEnter={ (color) => this.handleMouseEnter(index, color) }
+                      onMouseLeave={ () => this.handleMouseLeave() }
+                      showBarLabel={ showBarLabel }
+                      size={ size }
+                      upper={ finalUpper }
+                      values={ values } />
+                }
               </ChartTableVisual>
             </ChartTableRow>
           ) }

--- a/packages/axiom-charts/src/BarChart/utils.js
+++ b/packages/axiom-charts/src/BarChart/utils.js
@@ -1,9 +1,10 @@
 export const formatData = (key, data) => {
   const order = key.map(({ color }) => color);
 
-  return data.map(({ label, benchmark, values }) => ({
+  return data.map(({ label, benchmark, values, isFaded = false }) => ({
     label,
     benchmark,
+    isFaded,
     values: Object.keys(values)
       .map((color) => ({ color, value: values[color] }))
       .sort((a, b) => order.indexOf(a.color) - order.indexOf(b.color)),

--- a/packages/axiom-charts/src/BarChart/utils.test.js
+++ b/packages/axiom-charts/src/BarChart/utils.test.js
@@ -50,6 +50,7 @@ describe('BarChart (utils)', () => {
     expect(formatData(chartKey, data)).toEqual([{
       label: 'Family',
       benchmark: 100,
+      isFaded: false,
       values: [{
         value: 0,
         color: 'giant-leap',
@@ -63,6 +64,7 @@ describe('BarChart (utils)', () => {
     }, {
       label: 'Games',
       benchmark: 33,
+      isFaded: false,
       values: [{
         value: 40,
         color: 'giant-leap',
@@ -76,6 +78,7 @@ describe('BarChart (utils)', () => {
     }, {
       label: 'Family & Parenting',
       benchmark: 33,
+      isFaded: false,
       values: [{
         value: 50,
         color: 'giant-leap',
@@ -89,6 +92,7 @@ describe('BarChart (utils)', () => {
     }, {
       label: 'Technology',
       benchmark: 33,
+      isFaded: false,
       values: [{
         value: 69,
         color: 'giant-leap',
@@ -96,6 +100,7 @@ describe('BarChart (utils)', () => {
     }, {
       label: 'Books',
       benchmark: 33,
+      isFaded: false,
       values: [{
         value: 25,
         color: 'giant-leap',

--- a/packages/axiom-charts/src/ChartTable/ChartTable.css
+++ b/packages/axiom-charts/src/ChartTable/ChartTable.css
@@ -89,6 +89,10 @@
   color: var(--color-theme-text--subtle);
 }
 
+.ax-chart-table__label--faded {
+  opacity: var(--cmp-chart-opacity-faded);
+}
+
 .ax-chart-table__visual {
   flex: 1 1 0%;
 }

--- a/packages/axiom-charts/src/ChartTable/ChartTableLabel.js
+++ b/packages/axiom-charts/src/ChartTable/ChartTableLabel.js
@@ -1,18 +1,23 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Base } from '@brandwatch/axiom-components';
+import classnames from 'classnames';
 
 export default class ChartTableLabel extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
+    isFaded: PropTypes.bool,
     width: PropTypes.string.isRequired,
   };
 
   render() {
-    const { children, width, ...rest } = this.props;
+    const { children, width, isFaded = false, ...rest } = this.props;
+    const classes = classnames('ax-chart-table__label', {
+      'ax-chart-table__label--faded': isFaded,
+    });
 
     return (
-      <Base { ...rest } className="ax-chart-table__label" style={ { width } }>
+      <Base { ...rest } className={ classes } style={ { width } }>
         { children }
       </Base>
     );

--- a/packages/axiom-charts/src/ChartTable/ChartTableLabel.test.js
+++ b/packages/axiom-charts/src/ChartTable/ChartTableLabel.test.js
@@ -15,4 +15,10 @@ describe('ChartTableLabel', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders with isFaded property', () => {
+    const component = getComponent({ isFaded: true });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/axiom-charts/src/ChartTable/__snapshots__/ChartTableLabel.test.js.snap
+++ b/packages/axiom-charts/src/ChartTable/__snapshots__/ChartTableLabel.test.js.snap
@@ -12,3 +12,16 @@ exports[`ChartTableLabel renders with defaultProps 1`] = `
   Lorem Ipsum
 </div>
 `;
+
+exports[`ChartTableLabel renders with isFaded property 1`] = `
+<div
+  className="ax-chart-table__label ax-chart-table__label--faded"
+  style={
+    Object {
+      "width": "11rem",
+    }
+  }
+>
+  Lorem Ipsum
+</div>
+`;

--- a/site/components/Documentation/Resources/Charts/chartData.js
+++ b/site/components/Documentation/Resources/Charts/chartData.js
@@ -7,6 +7,7 @@ export const dotPlotKey = [
 export const dotPlotData = [{
   label: 'Family & Parenting',
   benchmark: 14,
+  isFaded: true,
   values: {
     'giant-leap': 17,
     'critical-mass': 15,


### PR DESCRIPTION
Adding an `isFaded` property to the `data` array enables the whole row to be faded/hidden. Initially I was thinking to pass the `isFaded` property to `BarChartBars` but what we want to achieve is to completely hide the bars and fade out the label.

![screen shot 2018-05-08 at 09 35 09](https://user-images.githubusercontent.com/1510613/39744024-25716bc8-52a3-11e8-8ec0-5fb8513a92b0.png)

**Note**: Needs removal of the modified `chartData#dotPlotData`