### PR TITLE
feat(BarChart): Add new prop showDifferenceArea

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -64,6 +64,8 @@ export default class BarChart extends Component {
     singleSelect: PropTypes.bool,
     /** Thickness of the bars */
     size: PropTypes.string,
+    /**  Control the appearance of the bar */
+    stretch: PropTypes.bool,
     /** Upper value of the data displayed on the chart */
     upper: PropTypes.number,
     /**
@@ -80,6 +82,7 @@ export default class BarChart extends Component {
   static defaultProps = {
     rowSpace: 'x2',
     showKey: true,
+    stretch: false,
   };
 
 
@@ -143,6 +146,7 @@ export default class BarChart extends Component {
       showKey,
       singleSelect,
       size,
+      stretch,
       upper = dataUpper,
       xAxisLabels,
       zoom,
@@ -202,6 +206,7 @@ export default class BarChart extends Component {
                     showBarLabel={ showBarLabel }
                     singleSelect={ singleSelect }
                     size={ size }
+                    stretch={ stretch }
                     upper={ finalUpper }
                     values={ values } />
               </ChartTableVisual>

--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -58,14 +58,14 @@ export default class BarChart extends Component {
     rowSpace: PropTypes.oneOf(['x1', 'x2', 'x3']),
     /** Option to always show the label next to bars, as opposed to on mouse over  */
     showBarLabel: PropTypes.bool,
+    /**  Control the appearance of the bar */
+    showDifferenceArea: PropTypes.bool,
     /** Control for toggling visibility of the key */
     showKey: PropTypes.bool,
     /** If set to true each color will be handled individually when hovering */
     singleSelect: PropTypes.bool,
     /** Thickness of the bars */
     size: PropTypes.string,
-    /**  Control the appearance of the bar */
-    stretch: PropTypes.bool,
     /** Upper value of the data displayed on the chart */
     upper: PropTypes.number,
     /**
@@ -82,7 +82,7 @@ export default class BarChart extends Component {
   static defaultProps = {
     rowSpace: 'x2',
     showKey: true,
-    stretch: false,
+    showDifferenceArea: false,
   };
 
 
@@ -146,7 +146,7 @@ export default class BarChart extends Component {
       showKey,
       singleSelect,
       size,
-      stretch,
+      showDifferenceArea,
       upper = dataUpper,
       xAxisLabels,
       zoom,
@@ -204,9 +204,9 @@ export default class BarChart extends Component {
                     onMouseEnter={ (color) => this.handleMouseEnter(index, color) }
                     onMouseLeave={ () => this.handleMouseLeave() }
                     showBarLabel={ showBarLabel }
+                    showDifferenceArea={ showDifferenceArea }
                     singleSelect={ singleSelect }
                     size={ size }
-                    stretch={ stretch }
                     upper={ finalUpper }
                     values={ values } />
               </ChartTableVisual>

--- a/packages/axiom-charts/src/BarChart/BarChartBars.js
+++ b/packages/axiom-charts/src/BarChart/BarChartBars.js
@@ -5,6 +5,7 @@ import atIds from '@brandwatch/axiom-automation-testing/ids';
 import { Small } from '@brandwatch/axiom-components';
 import Bar from '../Bar/Bar';
 import Bars from '../Bar/Bars';
+import CombinedBar from './CombinedBar';
 import BarChartBenchmarkLine from './BarChartBenchmarkLine';
 import ChartContext from '../ChartContext/ChartContext';
 
@@ -30,8 +31,13 @@ export default class BarChartBars extends Component {
     showBarLabel: PropTypes.bool,
     singleSelect: PropTypes.bool,
     size: PropTypes.string,
+    stretch: PropTypes.bool,
     upper: PropTypes.number,
     values: PropTypes.array.isRequired,
+  };
+
+  static defaultProps = {
+    stretch: false,
   };
 
   render() {
@@ -52,6 +58,7 @@ export default class BarChartBars extends Component {
       showBarLabel,
       singleSelect,
       size,
+      stretch,
       upper,
       values,
       onDropdownClose,
@@ -82,9 +89,36 @@ export default class BarChartBars extends Component {
               'ax-bar-chart__bar-label--hidden': !(showBarLabel || color === hoverColor),
             });
 
+            const isStretched = benchmarkValue > percent;
+
             const labelStyle = {
-              left: `${percent}%`,
+              left: `${stretch && isStretched ? benchmarkValue : percent}%`,
             };
+
+            const bar = (<Bar
+                color={ color }
+                data-ax-at={ atIds.BarChart.bar }
+                isFaded={ isFaded }
+                isHidden={ hideBars && isFaded }
+                onMouseEnter={ () => onMouseEnter(color) }
+                onMouseLeave={ onMouseLeave }
+                percent={ percent }
+                showLabel={ false }
+                size={ size } />);
+
+            const combineBar = stretch && (
+              <CombinedBar
+                  benchmarkValue={ benchmarkValue }
+                  color={ color }
+                  data-ax-at={ atIds.BarChart.bar }
+                  isFaded={ isFaded }
+                  isHidden={ hideBars && isFaded }
+                  onMouseEnter={ () => onMouseEnter(color) }
+                  onMouseLeave={ onMouseLeave }
+                  percent={ percent }
+                  showLabel={ false }
+                  size={ size } />
+              );
 
             return (
               <div className="ax-bar-chart__bar-container" key={ color }>
@@ -96,16 +130,7 @@ export default class BarChartBars extends Component {
                     onDropdownClose={ onDropdownClose }
                     onDropdownOpen={ () => onDropdownOpen(color) }
                     value={ value }>
-                  <Bar
-                      color={ color }
-                      data-ax-at={ atIds.BarChart.bar }
-                      isFaded={ isFaded }
-                      isHidden={ hideBars && isFaded }
-                      onMouseEnter={ () => onMouseEnter(color) }
-                      onMouseLeave={ onMouseLeave }
-                      percent={ percent }
-                      showLabel={ false }
-                      size={ size } />
+                  { combineBar || bar }
                 </ChartContext>
 
                 <div className={ labelClasses } style={ labelStyle }>

--- a/packages/axiom-charts/src/BarChart/BarChartBars.js
+++ b/packages/axiom-charts/src/BarChart/BarChartBars.js
@@ -29,15 +29,11 @@ export default class BarChartBars extends Component {
     onMouseEnter: PropTypes.func.isRequired,
     onMouseLeave: PropTypes.func.isRequired,
     showBarLabel: PropTypes.bool,
+    showDifferenceArea: PropTypes.bool,
     singleSelect: PropTypes.bool,
     size: PropTypes.string,
-    stretch: PropTypes.bool,
     upper: PropTypes.number,
     values: PropTypes.array.isRequired,
-  };
-
-  static defaultProps = {
-    stretch: false,
   };
 
   render() {
@@ -56,9 +52,9 @@ export default class BarChartBars extends Component {
       label,
       lower,
       showBarLabel,
+      showDifferenceArea,
       singleSelect,
       size,
-      stretch,
       upper,
       values,
       onDropdownClose,
@@ -92,33 +88,10 @@ export default class BarChartBars extends Component {
             const isStretched = benchmarkValue > percent;
 
             const labelStyle = {
-              left: `${stretch && isStretched ? benchmarkValue : percent}%`,
+              left: `${showDifferenceArea && isStretched ? benchmarkValue : percent}%`,
             };
 
-            const bar = (<Bar
-                color={ color }
-                data-ax-at={ atIds.BarChart.bar }
-                isFaded={ isFaded }
-                isHidden={ hideBars && isFaded }
-                onMouseEnter={ () => onMouseEnter(color) }
-                onMouseLeave={ onMouseLeave }
-                percent={ percent }
-                showLabel={ false }
-                size={ size } />);
-
-            const combineBar = stretch && (
-              <CombinedBar
-                  benchmarkValue={ benchmarkValue }
-                  color={ color }
-                  data-ax-at={ atIds.BarChart.bar }
-                  isFaded={ isFaded }
-                  isHidden={ hideBars && isFaded }
-                  onMouseEnter={ () => onMouseEnter(color) }
-                  onMouseLeave={ onMouseLeave }
-                  percent={ percent }
-                  showLabel={ false }
-                  size={ size } />
-              );
+            const FinalBar = showDifferenceArea ? CombinedBar : Bar;
 
             return (
               <div className="ax-bar-chart__bar-container" key={ color }>
@@ -130,7 +103,17 @@ export default class BarChartBars extends Component {
                     onDropdownClose={ onDropdownClose }
                     onDropdownOpen={ () => onDropdownOpen(color) }
                     value={ value }>
-                  { combineBar || bar }
+                  <FinalBar
+                      benchmarkValue={ showDifferenceArea ? benchmarkValue : null }
+                      color={ color }
+                      data-ax-at={ atIds.BarChart.bar }
+                      isFaded={ isFaded }
+                      isHidden={ hideBars && isFaded }
+                      onMouseEnter={ () => onMouseEnter(color) }
+                      onMouseLeave={ onMouseLeave }
+                      percent={ percent }
+                      showLabel={ false }
+                      size={ size } />
                 </ChartContext>
 
                 <div className={ labelClasses } style={ labelStyle }>

--- a/packages/axiom-charts/src/BarChart/CombinedBar.css
+++ b/packages/axiom-charts/src/BarChart/CombinedBar.css
@@ -1,0 +1,5 @@
+.ax-bar-chart__combined-bar_diff {
+  position: absolute;
+  top: 0;
+  width: 100%;
+}

--- a/packages/axiom-charts/src/BarChart/CombinedBar.css
+++ b/packages/axiom-charts/src/BarChart/CombinedBar.css
@@ -1,4 +1,4 @@
-.ax-bar-chart__combined-bar_diff {
+.ax-bar-chart__combined-bar-diff {
   position: absolute;
   top: 0;
   width: 100%;

--- a/packages/axiom-charts/src/BarChart/CombinedBar.js
+++ b/packages/axiom-charts/src/BarChart/CombinedBar.js
@@ -29,7 +29,7 @@ export default class CombinedBar extends Component {
             percent={ percent }
             { ...rest } />
 
-        { isStretched && (<div className="ax-bar-chart__combined-bar_diff" style={ stripedBarStyle }>
+        { isStretched && (<div className="ax-bar-chart__combined-bar-diff" style={ stripedBarStyle }>
           <Bar
               fillMode="striped"
               percent={ stripedBarWidth }

--- a/packages/axiom-charts/src/BarChart/CombinedBar.js
+++ b/packages/axiom-charts/src/BarChart/CombinedBar.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import omit from 'lodash.omit';
+import { Bar } from '@brandwatch/axiom-charts';
+import './CombinedBar.css';
+
+export default class CombinedBar extends Component {
+  static propTypes = {
+    benchmarkValue: PropTypes.number.isRequired,
+    percent: PropTypes.number.isRequired,
+  };
+
+  render() {
+    const { percent, benchmarkValue, ...rest } = this.props;
+    const isStretched = benchmarkValue > percent;
+
+    const stripedBarWidth = isStretched ? benchmarkValue - percent : percent - benchmarkValue;
+    const stripedBarStyle = {
+      left: isStretched ? `${percent}%` : `${benchmarkValue}%`,
+    };
+
+    const stripedBarProps = omit(rest, [
+      'onClick',
+    ]);
+
+    return (
+      <React.Fragment>
+        <Bar
+            percent={ percent }
+            { ...rest } />
+
+        { isStretched && (<div className="ax-bar-chart__combined-bar_diff" style={ stripedBarStyle }>
+          <Bar
+              fillMode="striped"
+              percent={ stripedBarWidth }
+              { ...stripedBarProps } />
+        </div>) }
+      </React.Fragment>
+    );
+  }
+}

--- a/packages/axiom-charts/src/BarChart/CombinedBar.test.js
+++ b/packages/axiom-charts/src/BarChart/CombinedBar.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import CombinedBar from './CombinedBar';
+
+function getComponent(props = {}) {
+  return renderer.create(
+    <CombinedBar { ...props } />
+  );
+}
+
+describe('CombinedBar', () => {
+  it('renders a single bar when benchmark value is less than current value', () => {
+    const component = getComponent({
+      benchmarkValue: 10,
+      percent: 50,
+    });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders an additional striped bar when benchmark value is grather than current value', () => {
+    const component = getComponent({
+      benchmarkValue: 50,
+      percent: 10,
+    });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/axiom-charts/src/BarChart/__snapshots__/CombinedBar.test.js.snap
+++ b/packages/axiom-charts/src/BarChart/__snapshots__/CombinedBar.test.js.snap
@@ -76,7 +76,7 @@ Array [
     </div>
 </div>,
   <div
-    className="ax-bar-chart__combined-bar_diff"
+    className="ax-bar-chart__combined-bar-diff"
     style={
         Object {
             "left": "10%",

--- a/packages/axiom-charts/src/BarChart/__snapshots__/CombinedBar.test.js.snap
+++ b/packages/axiom-charts/src/BarChart/__snapshots__/CombinedBar.test.js.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CombinedBar renders a single bar when benchmark value is less than current value 1`] = `
+<div
+  className="ax-bars__bar"
+  onClick={undefined}
+  style={
+    Object {
+      "height": false,
+      "width": "50%",
+    }
+  }
+>
+  <div
+    className="ax-bars__bar-rect ax-bars__bar-rect--undefined"
+    style={
+      Object {
+        "height": undefined,
+        "minHeight": "1rem",
+        "minWidth": false,
+        "width": false,
+      }
+    }
+  >
+    <div
+      className="ax-bars__bar--solid"
+    />
+  </div>
+  <div
+    className="ax-bars__bar-label ax-bars__bar-label--hidden"
+  >
+    <small
+      className="ax-text--size-small"
+    >
+      50%
+    </small>
+  </div>
+</div>
+`;
+
+exports[`CombinedBar renders an additional striped bar when benchmark value is grather than current value 1`] = `
+Array [
+  <div
+    className="ax-bars__bar"
+    onClick={undefined}
+    style={
+        Object {
+            "height": false,
+            "width": "10%",
+          }
+    }
+>
+    <div
+        className="ax-bars__bar-rect ax-bars__bar-rect--undefined"
+        style={
+            Object {
+                "height": undefined,
+                "minHeight": "1rem",
+                "minWidth": false,
+                "width": false,
+              }
+        }
+    >
+        <div
+            className="ax-bars__bar--solid"
+        />
+    </div>
+    <div
+        className="ax-bars__bar-label ax-bars__bar-label--hidden"
+    >
+        <small
+            className="ax-text--size-small"
+        >
+            10%
+        </small>
+    </div>
+</div>,
+  <div
+    className="ax-bar-chart__combined-bar_diff"
+    style={
+        Object {
+            "left": "10%",
+          }
+    }
+>
+    <div
+        className="ax-bars__bar"
+        onClick={undefined}
+        style={
+            Object {
+                "height": false,
+                "width": "40%",
+              }
+        }
+    >
+        <div
+            className="ax-bars__bar-rect ax-bars__bar-rect--undefined"
+            style={
+                Object {
+                    "height": undefined,
+                    "minHeight": "1rem",
+                    "minWidth": false,
+                    "width": false,
+                  }
+            }
+        >
+            <div
+                className="ax-bars__bar--striped"
+            />
+        </div>
+        <div
+            className="ax-bars__bar-label ax-bars__bar-label--hidden"
+        >
+            <small
+                className="ax-text--size-small"
+            >
+                40%
+            </small>
+        </div>
+    </div>
+</div>,
+]
+`;


### PR DESCRIPTION
Adds a new  prop `showDifferenceArea` to the BarChart component. Setting this property to `true` (`false` by default) will cause the BarChart to add a striped bar between the bar and benchmark line (see attached screenshot). 


[Demo](https://brave-keller-55c6a8.netlify.com/docs/packages/axiom-charts/bar-chart)

![screen shot 2018-05-14 at 11 46 35](https://user-images.githubusercontent.com/1393946/39993954-068fd49a-5778-11e8-8370-52f096354d7a.png)
