### PR TITLE
feat(BarChart): Changed xAxisLabel property to be a method that returns an array of labels

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -69,10 +69,9 @@ export default class BarChart extends Component {
     /** Upper value of the data displayed on the chart */
     upper: PropTypes.number,
     /**
-     * Labels to be shown along the xAxis, also used to determine where
-     * grid lines are drawn
+     * Method which returns the labels to be shown along the xAxis, also used to determine where grid lines are drawn
      */
-    xAxisLabels: PropTypes.arrayOf(PropTypes.string),
+    xAxisLabels: PropTypes.func,
     /** Control for toggling the zoomed view */
     zoom: PropTypes.bool,
     /** Options for the maximum zoom value */
@@ -83,6 +82,7 @@ export default class BarChart extends Component {
     rowSpace: 'x2',
     showKey: true,
     showDifferenceArea: false,
+    xAxisLabels: () => [],
   };
 
 
@@ -163,8 +163,10 @@ export default class BarChart extends Component {
     const finalZoomMax = Math.max(dataUpper, Math.min(zoomMax !== undefined ? zoomMax : dataUpper, finalUpper));
     const zoomTo = ((finalZoomMax - finalLower) / (finalUpper - finalLower)) * 100;
 
+    const finalXAxisLabels = xAxisLabels(finalLower, finalUpper);
+
     return (
-      <ChartTable { ...rest } xAxisLabels={ xAxisLabels }>
+      <ChartTable { ...rest } xAxisLabels={ finalXAxisLabels }>
         <ChartTableRows
             collapsedVisibleRowCount={ collapsedVisibleRowCount }
             expandButtonSuffix={ expandButtonSuffix }
@@ -172,7 +174,7 @@ export default class BarChart extends Component {
             lower={ dataUpper }
             space={ rowSpace }
             upper={ finalUpper }
-            xAxisLabels={ xAxisLabels }
+            xAxisLabels={ finalXAxisLabels }
             zoom={ zoom }
             zoomTo={ zoom ? zoomTo : undefined }>
           { formattedData.map(({ values, label, benchmark }, index) =>

--- a/packages/axiom-charts/src/DotPlotChart/DotPlotChart.js
+++ b/packages/axiom-charts/src/DotPlotChart/DotPlotChart.js
@@ -62,10 +62,9 @@ export default class DotPlotChart extends Component {
     /** Upper value of the data displayed on the chart */
     upper: PropTypes.number,
     /**
-     * Labels to be shown along the xAxis, also used to determine where
-     * grid lines are drawn
+     * Method which returns the labels to be shown along the xAxis, also used to determine where grid lines are drawn
      */
-    xAxisLabels: PropTypes.arrayOf(PropTypes.string),
+    xAxisLabels: PropTypes.func,
     /** Control for toggling the zoomed view */
     zoom: PropTypes.bool,
     /** Options for the maximum zoom value */
@@ -75,6 +74,7 @@ export default class DotPlotChart extends Component {
   static defaultProps = {
     showKey: true,
     zoomMax: 50,
+    xAxisLabels: () => [],
   };
 
   constructor(props) {
@@ -149,15 +149,16 @@ export default class DotPlotChart extends Component {
     const finalUpper = Math.max(upper, dataUpper);
     const finalZoomMax = Math.max(dataUpper, Math.min(zoomMax !== undefined ? zoomMax : dataUpper, finalUpper));
     const zoomTo = ((finalZoomMax - finalLower) / (finalUpper - finalLower)) * 100;
+    const finalXAxisLabels = xAxisLabels(finalLower, finalUpper);
 
     return (
-      <ChartTable { ...rest } xAxisLabels={ xAxisLabels }>
+      <ChartTable { ...rest } xAxisLabels={ finalXAxisLabels }>
         <ChartTableRows
             collapsedVisibleRowCount={ collapsedVisibleRowCount }
             expandButtonSuffix={ expandButtonSuffix }
             labelColumnWidth={ labelColumnWidth }
             space="x2"
-            xAxisLabels={ xAxisLabels }
+            xAxisLabels={ finalXAxisLabels }
             zoomTo={ zoom ? zoomTo : undefined }>
           { formattedData.map(({ values, benchmark, label }, index) =>
             <ChartTableRow

--- a/packages/axiom-charts/src/LineChart/LineChart.js
+++ b/packages/axiom-charts/src/LineChart/LineChart.js
@@ -54,10 +54,9 @@ export default class LineChart extends Component {
     /** Upper value of the data displayed on the chart */
     upper: PropTypes.number,
     /**
-     * Labels to be shown along the xAxis, also used to determine where
-     * grid lines are drawn
+     * Method which returns the labels to be shown along the xAxis, also used to determine where grid lines are drawn
      */
-    xAxisLabels: PropTypes.arrayOf(PropTypes.node),
+    xAxisLabels: PropTypes.func,
     /** The title that appears along the xAxis */
     xAxisTitle: PropTypes.node,
     /**
@@ -70,6 +69,10 @@ export default class LineChart extends Component {
     })),
     /** The title that appears along the yAxis */
     yAxisTitle: PropTypes.node,
+  };
+
+  static defaultProps = {
+    xAxisLabels: () => [],
   };
 
   constructor(props) {
@@ -135,12 +138,13 @@ export default class LineChart extends Component {
     const finalUpper = Math.max(upper, dataUpper);
     const labelMap = chartKey.reduce((map, { color, label, style }) =>
       ({ ...map, [label]: { color, style } }), {});
+    const finalXAxisLabels = xAxisLabels(finalLower, finalUpper);
 
     return (
       <ChartLayout { ...rest }>
         { xAxisTitle && <ChartLayoutTitle axis="x">{ xAxisTitle }</ChartLayoutTitle> }
         { yAxisTitle && <ChartLayoutTitle axis="y">{ yAxisTitle }</ChartLayoutTitle> }
-        { xAxisLabels && <ChartLayoutLabels axis="x" labels={ xAxisLabels } /> }
+        { finalXAxisLabels.length > 0 && <ChartLayoutLabels axis="x" labels={ finalXAxisLabels } /> }
         { yAxisLabels && (
           <ChartLayoutLabels
               axis="y"

--- a/site/components/Documentation/Resources/Charts/BarChart.js
+++ b/site/components/Documentation/Resources/Charts/BarChart.js
@@ -24,7 +24,7 @@ export default class Documentation extends Component {
               labelColumnWidth="11rem"
               lower={ 0 }
               upper={ 100 }
-              xAxisLabels={ [ '0', '10', '20', '30', '40', '50', '60', '70', '80', '90', '100'] }/>
+              xAxisLabels={ () => [ '0', '10', '20', '30', '40', '50', '60', '70', '80', '90', '100'] }/>
         </DocumentationShowCase>
 
         <DocumentationApi components={ [

--- a/site/components/Documentation/Resources/Charts/DotPlotChart.js
+++ b/site/components/Documentation/Resources/Charts/DotPlotChart.js
@@ -25,7 +25,7 @@ export default class Documentation extends Component {
               labelColumnWidth="11rem"
               lower={ 0 }
               upper={ 100 }
-              xAxisLabels={ [ '0', '10', '20', '30', '40', '50', '60', '70', '80', '90', '100'] }/>
+              xAxisLabels={ () => [ '0', '10', '20', '30', '40', '50', '60', '70', '80', '90', '100'] }/>
         </DocumentationShowCase>
 
         <DocumentationApi components={ [

--- a/site/components/Documentation/Resources/Charts/LineChart.js
+++ b/site/components/Documentation/Resources/Charts/LineChart.js
@@ -22,7 +22,7 @@ export default class Documentation extends Component {
               height="12rem"
               lower={ 0 }
               upper={ 30 }
-              xAxisLabels={ [
+              xAxisLabels={ () => [
                 'Dec 1',
                 'Dec 3',
                 'Dec 5',


### PR DESCRIPTION
**BREAKING CHANGE:** The BarChart now only accepts a method for the xAxisLabel property instead of an array. The method receives a "lower" and an "upper" argument and expects an array to be returned.

Currently you can pass in an array of strings to render the labels on the x-axis. In order to enable more dynamic rendering this is changed to be a method now. It should still return an array of strings.

Updating existing code should be straight-forward by just wrapping the array in a method:
```javascript
<BarChart xAxisLabel={ ['0', '50', '100'] } />
// should be changed to this:
<BarChart xAxisLabel={ (lower, upper) => ['0', '50', '100'] } />
```