### PR TITLE
fix(BarChart): vertically center label when size is specified

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChart.css
+++ b/packages/axiom-charts/src/BarChart/BarChart.css
@@ -57,10 +57,10 @@
 
 .ax-bar-chart__bar-container .ax-bar-chart__bar-label {
   position: absolute;
-  top: 0;
-  align-self: center;
+  top: 50%;
   margin-right: calc(var(--cmp-chart-label-width) * -1);
   padding-left: var(--cmp-chart-label-margin);
+  transform: translateY(-50%);
   line-height: var(--cmp-chart-label-line-height);
   transition: opacity var(--transition-time-base) var(--transition-function);
 }


### PR DESCRIPTION
When using `size` the label next to the bar is not vertically centered anymore:

#### Before
![image](https://user-images.githubusercontent.com/111471/40101565-202eafa4-58e8-11e8-995a-d217d3e34887.png)

Set height to `100%` and center it with flexbox.

#### After
![image](https://user-images.githubusercontent.com/111471/40102710-829694a6-58eb-11e8-820d-76adf8e63d93.png)
