### PR TITLE
feat(Image):Add border color property to avatar and image

### DIFF
--- a/packages/axiom-components/src/Avatar/Avatar.js
+++ b/packages/axiom-components/src/Avatar/Avatar.js
@@ -4,8 +4,34 @@ import Image from '../Image/Image';
 
 export default class Avatar extends Component {
   static propTypes = {
-    /** Border around the avatar */
+    /** Border size around the avatar */
     border: PropTypes.oneOf(['small', 'large']),
+    /** Border colour around the avatar */
+    borderColor: PropTypes.oneOf([
+      'highlight',
+      'success',
+      'error',
+      'tiny-clanger',
+      'critical-mass',
+      'fantastic-voyage',
+      'paradise-lost',
+      'serene-sea',
+      'electric-dreams',
+      'giant-leap',
+      'moon-lagoon',
+      'space-invader',
+      'terra-form',
+      'primeval-soup',
+      'sun-maker',
+      'new-horizon',
+      'blast-off',
+      'crash-course',
+      'ground-control',
+      'space-oddity',
+      'deep-thought',
+      'luna-dust',
+      'carbon',
+    ]),
     /** Fallback content when the image fails to load */
     children: PropTypes.node,
     /** Size of the Avatar */
@@ -21,6 +47,7 @@ export default class Avatar extends Component {
   render() {
     const {
       border,
+      borderColor,
       children,
       size,
       src,
@@ -30,6 +57,7 @@ export default class Avatar extends Component {
     return (
       <Image { ...rest }
           border={ border }
+          borderColor={ borderColor }
           height={ size }
           shape="circle"
           src={ src }

--- a/packages/axiom-components/src/Image/Image.css
+++ b/packages/axiom-components/src/Image/Image.css
@@ -11,3 +11,27 @@
 
 .ax-image--border-small { border-width: var(--component-border-width-small); }
 .ax-image--border-large { border-width: var(--component-border-width-large); }
+
+.ax-image--border-color-highlight { border-color: var(--color-ui-highlight); }
+.ax-image--border-color-success { border-color: var(--color-ui-success); }
+.ax-image--border-color-error { border-color: var(--color-ui-error); }
+.ax-image--border-color-tiny-clanger { border-color: var(--color-product-tiny-clanger); }
+.ax-image--border-color-critical-mass { border-color: var(--color-product-critical-mass); }
+.ax-image--border-color-fantastic-voyage { border-color: var(--color-product-fantastic-voyage); }
+.ax-image--border-color-paradise-lost { border-color: var(--color-product-paradise-lost); }
+.ax-image--border-color-serene-sea { border-color: var(--color-product-serene-sea); }
+.ax-image--border-color-electric-dreams { border-color: var(--color-product-electric-dreams); }
+.ax-image--border-color-giant-leap { border-color: var(--color-product-giant-leap); }
+.ax-image--border-color-moon-lagoon { border-color: var(--color-product-moon-lagoon); }
+.ax-image--border-color-space-invader { border-color: var(--color-product-space-invader); }
+.ax-image--border-color-terra-form { border-color: var(--color-product-terra-form); }
+.ax-image--border-color-primeval-soup { border-color: var(--color-product-primeval-soup); }
+.ax-image--border-color-sun-maker { border-color: var(--color-product-sun-maker); }
+.ax-image--border-color-new-horizon { border-color: var(--color-product-new-horizon); }
+.ax-image--border-color-blast-off { border-color: var(--color-product-blast-off); }
+.ax-image--border-color-crash-course { border-color: var(--color-product-crash-course); }
+.ax-image--border-color-ground-control { border-color: var(--color-product-ground-control); }
+.ax-image--border-color-space-oddity { border-color: var(--color-product-space-oddity); }
+.ax-image--border-color-deep-thought { border-color: var(--color-product-deep-thought); }
+.ax-image--border-color-luna-dust { border-color: var(--color-product-luna-dust); }
+.ax-image--border-color-rgb-ui-carbon { border-color: var(--rgb-ui-carbon); }

--- a/packages/axiom-components/src/Image/Image.js
+++ b/packages/axiom-components/src/Image/Image.js
@@ -7,8 +7,34 @@ import './Image.css';
 
 export default class Image extends Component {
   static propTypes = {
-    /** Border applied around the image */
+    /** Border size around the image */
     border: PropTypes.oneOf(['small', 'large']),
+    /** Border colour around the image */
+    borderColor: PropTypes.oneOf([
+      'highlight',
+      'success',
+      'error',
+      'tiny-clanger',
+      'critical-mass',
+      'fantastic-voyage',
+      'paradise-lost',
+      'serene-sea',
+      'electric-dreams',
+      'giant-leap',
+      'moon-lagoon',
+      'space-invader',
+      'terra-form',
+      'primeval-soup',
+      'sun-maker',
+      'new-horizon',
+      'blast-off',
+      'crash-course',
+      'ground-control',
+      'space-oddity',
+      'deep-thought',
+      'luna-dust',
+      'carbon',
+    ]),
     /** Fallback content when the image fails to load */
     children: PropTypes.node,
     /** Height of the image. When shape is circle this will be ignored and width will be applied. */
@@ -35,6 +61,7 @@ export default class Image extends Component {
   render() {
     const {
       border,
+      borderColor,
       children,
       height,
       maxWidth,
@@ -54,6 +81,7 @@ export default class Image extends Component {
 
     const classes = classnames('ax-image', `ax-image--${shape}`, {
       [`ax-image--border-${border}`]: border,
+      [`ax-image--border-color-${borderColor}`]: borderColor,
     });
 
     return (


### PR DESCRIPTION
[JIRA]

This adds support for coloured borders around images and, by extension, avatars which is necessary to highlight influencer profiles inside an audience.

todo
- [ ] empty buffer around border