### PR TITLE
refactor(CombinedBar): To accept tooltip and dropdown props

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChartBars.js
+++ b/packages/axiom-charts/src/BarChart/BarChartBars.js
@@ -3,11 +3,9 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import atIds from '@brandwatch/axiom-automation-testing/ids';
 import { Base, Small } from '@brandwatch/axiom-components';
-import Bar from '../Bar/Bar';
 import Bars from '../Bar/Bars';
 import CombinedBar from './CombinedBar';
 import BarChartBenchmarkLine from './BarChartBenchmarkLine';
-import ChartContext from '../ChartContext/ChartContext';
 
 export default class BarChartBars extends Component {
   static propTypes = {
@@ -97,31 +95,26 @@ export default class BarChartBars extends Component {
               left: `${showDifferenceArea && isStretched ? benchmarkValue : percent}%`,
             };
 
-            const FinalBar = showDifferenceArea ? CombinedBar : Bar;
-
             return (
               <div className="ax-bar-chart__bar-container" key={ color }>
-                <ChartContext
+                <CombinedBar
                     DropdownContext={ DropdownContext }
                     TooltipContext={ TooltipContext }
+                    benchmarkValue={ showDifferenceArea ? benchmarkValue : null }
                     color={ color }
                     data={ data }
+                    data-ax-at={ atIds.BarChart.bar }
+                    isFaded={ isFaded }
+                    isHidden={ hideBars && isFaded }
                     label={ label }
                     onDropdownClose={ onDropdownClose }
                     onDropdownOpen={ () => onDropdownOpen(color) }
-                    value={ value }>
-                  <FinalBar
-                      benchmarkValue={ showDifferenceArea ? benchmarkValue : null }
-                      color={ color }
-                      data-ax-at={ atIds.BarChart.bar }
-                      isFaded={ isFaded }
-                      isHidden={ hideBars && isFaded }
-                      onMouseEnter={ () => onMouseEnter(color) }
-                      onMouseLeave={ onMouseLeave }
-                      percent={ percent }
-                      showLabel={ false }
-                      size={ size } />
-                </ChartContext>
+                    onMouseEnter={ () => onMouseEnter(color) }
+                    onMouseLeave={ onMouseLeave }
+                    percent={ percent }
+                    showLabel={ false }
+                    size={ size }
+                    value={ value } />
 
                 <div className={ labelClasses } style={ labelStyle }>
                   <Small textStrong={ isHovered }>{ barLabel ? barLabel({ value, data, color, label }) : value }</Small>

--- a/packages/axiom-charts/src/BarChart/CombinedBar.js
+++ b/packages/axiom-charts/src/BarChart/CombinedBar.js
@@ -1,17 +1,38 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import omit from 'lodash.omit';
-import { Bar } from '@brandwatch/axiom-charts';
+import Bar from '../Bar/Bar';
+import ChartContext from '../ChartContext/ChartContext';
 import './CombinedBar.css';
 
 export default class CombinedBar extends Component {
   static propTypes = {
+    DropdownContext: PropTypes.func,
+    TooltipContext: PropTypes.func,
     benchmarkValue: PropTypes.number.isRequired,
+    color: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    label: PropTypes.node.isRequired,
+    onDropdownClose: PropTypes.func.isRequired,
+    onDropdownOpen: PropTypes.func.isRequired,
     percent: PropTypes.number.isRequired,
+    value: PropTypes.number.isRequired,
   };
 
   render() {
-    const { percent, benchmarkValue, ...rest } = this.props;
+    const {
+      DropdownContext,
+      TooltipContext,
+      benchmarkValue,
+      color,
+      data,
+      label,
+      onDropdownClose,
+      onDropdownOpen,
+      percent,
+      value,
+      ...rest
+    } = this.props;
     const isStretched = benchmarkValue > percent;
 
     const stripedBarWidth = isStretched ? benchmarkValue - percent : percent - benchmarkValue;
@@ -25,12 +46,24 @@ export default class CombinedBar extends Component {
 
     return (
       <React.Fragment>
-        <Bar
-            percent={ percent }
-            { ...rest } />
+        <ChartContext
+            DropdownContext={ DropdownContext }
+            TooltipContext={ TooltipContext }
+            color={ color }
+            data={ data }
+            label={ label }
+            onDropdownClose={ onDropdownClose }
+            onDropdownOpen={ () => onDropdownOpen(color) }
+            value={ value }>
+          <Bar
+              color={ color }
+              percent={ percent }
+              { ...rest } />
+        </ChartContext>
 
         { isStretched && (<div className="ax-bar-chart__combined-bar-diff" style={ stripedBarStyle }>
           <Bar
+              color={ color }
               fillMode="striped"
               percent={ stripedBarWidth }
               { ...stripedBarProps } />

--- a/packages/axiom-charts/src/BarChart/CombinedBar.test.js
+++ b/packages/axiom-charts/src/BarChart/CombinedBar.test.js
@@ -2,7 +2,19 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import CombinedBar from './CombinedBar';
 
-function getComponent(props = {}) {
+function getComponent(newProps = {}) {
+  const props = {
+    DropdownContext: jest.fn(),
+    TooltipContext: jest.fn(),
+    onDropdownClose: jest.fn(),
+    onDropdownOpen: jest.fn(),
+    data: [],
+    color: 'critical-mass',
+    label: 'Possitve',
+    value: 4321,
+    ...newProps,
+  };
+
   return renderer.create(
     <CombinedBar { ...props }
         color="giant-leap"

--- a/packages/axiom-charts/src/BarChart/__snapshots__/CombinedBar.test.js.snap
+++ b/packages/axiom-charts/src/BarChart/__snapshots__/CombinedBar.test.js.snap
@@ -2,9 +2,11 @@
 
 exports[`CombinedBar renders a single bar when benchmark value is less than current value 1`] = `
 <div
-  className="ax-bars__bar"
+  className="ax-bars__bar ax-bars__bar--clickable"
   direction="right"
-  onClick={undefined}
+  onClick={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
   style={
     Object {
       "height": false,
@@ -42,9 +44,11 @@ exports[`CombinedBar renders a single bar when benchmark value is less than curr
 exports[`CombinedBar renders an additional striped bar when benchmark value is grather than current value 1`] = `
 Array [
   <div
-    className="ax-bars__bar"
+    className="ax-bars__bar ax-bars__bar--clickable"
     direction="right"
-    onClick={undefined}
+    onClick={[Function]}
+    onMouseLeave={[Function]}
+    onMouseMove={[Function]}
     style={
         Object {
             "height": false,


### PR DESCRIPTION
There is a need to be able to add two tooltips on a striped bar. This PR is in preparation for the actual PR which I will raise soon. It moves `ChartContext` into `CombinedBar` and to retain the previous behaviour. 