### PR TITLE
fix(ChartTableLabel): Apply disable color on toggle icon when row is hidden

### DIFF
--- a/packages/axiom-charts/src/ChartTable/ChartTableLabel.js
+++ b/packages/axiom-charts/src/ChartTable/ChartTableLabel.js
@@ -42,7 +42,7 @@ export default class ChartTableLabel extends Component {
           </GridCell>
           { onToggleRowVisibility &&
             <GridCell cloak={ !disabled } shrink>
-              <Link style="subtle">
+              <Link style="subtle" textColor={ disabled ? 'disabled' : null }>
                 <Icon name="preview" />
               </Link>
             </GridCell>

--- a/packages/axiom-charts/src/ChartTable/__snapshots__/ChartTableLabel.test.js.snap
+++ b/packages/axiom-charts/src/ChartTable/__snapshots__/ChartTableLabel.test.js.snap
@@ -74,7 +74,7 @@ exports[`ChartTableLabel renders with onToggleRowVisibility and disabled 1`] = `
         }
       >
         <a
-          className="ax-link ax-link--style-subtle"
+          className="ax-link ax-link--style-subtle ax-text--color-disabled"
         >
           <svg
             className="ax-icon ax-icon--preview"


### PR DESCRIPTION


### Before
<img width="425" alt="screen shot 2018-05-25 at 12 25 30" src="https://user-images.githubusercontent.com/1393946/40540062-1da9839a-6017-11e8-859c-573fb6a64bca.png">

### After
<img width="383" alt="screen shot 2018-05-25 at 12 25 12" src="https://user-images.githubusercontent.com/1393946/40540063-1e38ddf6-6017-11e8-9d22-0d406c877f95.png">

…hidden