### PR TITLE
feat(Dropdown): Remove dropdown mask

### DIFF
--- a/packages/axiom-components/src/AlertDropdown/AlertDropdown.js
+++ b/packages/axiom-components/src/AlertDropdown/AlertDropdown.js
@@ -85,9 +85,10 @@ class AlertDropdown extends Component {
       <Position
           { ...rest }
           isVisible={ isVisible }
-          onMaskClick={ () => this.close() }
           position="bottom">
-        <PositionTarget>{ findComponent(children, AlertDropdownTargetRef) }</PositionTarget>
+        <PositionTarget>
+          { findComponent(children, AlertDropdownTargetRef) }
+        </PositionTarget>
         <PositionSource>{ findComponent(children, AlertDropdownSourceRef) }</PositionSource>
       </Position>
     );

--- a/packages/axiom-components/src/Base/Base.css
+++ b/packages/axiom-components/src/Base/Base.css
@@ -143,3 +143,7 @@
     pointer-events: all;
   }
 }
+
+.ax-pointer--disabled {
+  pointer-events: none;
+}

--- a/packages/axiom-components/src/Base/Base.js
+++ b/packages/axiom-components/src/Base/Base.js
@@ -34,6 +34,8 @@ export default class Base extends Component {
      * Opposite of `visibleUntil`.
      */
     hiddenUntil: PropTypes.oneOf(['small', 'medium', 'large']),
+    /** disables pointer events */
+    pointerEventsDisabled: PropTypes.bool,
     /** Vertical margins given to the element */
     space: PropTypes.oneOf(['x0', 'x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x8']),
     /**
@@ -135,6 +137,7 @@ export default class Base extends Component {
       cloakContainer,
       container,
       hiddenUntil,
+      pointerEventsDisabled,
       space,
       sticky,
       textBreak,
@@ -181,6 +184,7 @@ export default class Base extends Component {
       'ax-text--strong': textStrong,
       [`ax-text--underline-${underline}`]: underline,
       [`ax-theme--${theme}`]: theme,
+      'ax-pointer--disabled': pointerEventsDisabled,
     });
 
     if (sticky) {

--- a/packages/axiom-components/src/DataPicker/__snapshots__/DataPicker.test.js.snap
+++ b/packages/axiom-components/src/DataPicker/__snapshots__/DataPicker.test.js.snap
@@ -52,6 +52,7 @@ exports[`DataPicker renders with defaultProps 1`] = `
                 data-ax-at="9c4d25dadaa7"
                 onClick={[Function]}
                 onFocus={[Function]}
+                pointerEventsDisabled={false}
               >
                 <a
                   className="ax-link ax-link--style-body"
@@ -173,6 +174,7 @@ exports[`DataPicker renders with just DataPickerDropdown 1`] = `
                 data-ax-at="9c4d25dadaa7"
                 onClick={[Function]}
                 onFocus={[Function]}
+                pointerEventsDisabled={false}
               >
                 <a
                   className="ax-link ax-link--style-body"
@@ -358,6 +360,7 @@ exports[`DataPicker renders with onSelectColor 1`] = `
                 data-ax-at="9c4d25dadaa7"
                 onClick={[Function]}
                 onFocus={[Function]}
+                pointerEventsDisabled={false}
               >
                 <a
                   className="ax-link ax-link--style-body"
@@ -479,6 +482,7 @@ exports[`DataPicker renders with value 1`] = `
                 data-ax-at="9c4d25dadaa7"
                 onClick={[Function]}
                 onFocus={[Function]}
+                pointerEventsDisabled={false}
               >
                 <a
                   className="ax-link ax-link--style-body"

--- a/packages/axiom-components/src/Dropdown/Dropdown.js
+++ b/packages/axiom-components/src/Dropdown/Dropdown.js
@@ -88,9 +88,12 @@ export default class Dropdown extends Component {
           { ...rest }
           isVisible={ isVisible }
           offset={ offset }
-          onMaskClick={ () => this.close() }
           position={ position }>
-        <PositionTarget>{ findComponent(children, DropdownTargetRef) }</PositionTarget>
+        <PositionTarget>
+          { React.cloneElement(findComponent(children, DropdownTargetRef), {
+            pointerEventsDisabled: isVisible,
+          } ) }
+        </PositionTarget>
         <PositionSource>{ findComponent(children, DropdownSourceRef) }</PositionSource>
       </Position>
     );

--- a/packages/axiom-components/src/Dropdown/DropdownContext.js
+++ b/packages/axiom-components/src/Dropdown/DropdownContext.js
@@ -39,6 +39,7 @@ export default class DropdownContext extends Component {
   constructor(props) {
     super(props);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleClick = this.handleClick.bind(this);
   }
 
   componentWillMount() {
@@ -47,6 +48,17 @@ export default class DropdownContext extends Component {
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleKeyDown);
+    document.removeEventListener('mousedown', this.handleClick);
+  }
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleClick);
+  }
+
+  handleClick() {
+    if (!this.el.contains(event.target)) {
+      return this.context.closeDropdown();
+    }
   }
 
   getFocusedMenuItem() {

--- a/packages/axiom-components/src/Position/Position.css
+++ b/packages/axiom-components/src/Position/Position.css
@@ -6,12 +6,3 @@
 .ax-position--arrow {
   margin: calc((var(--cmp-context-tip-edge-to-edge) * 0.5) + var(--spacing-grid-size--x1));
 }
-
-.ax-position__mask {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: var(--z-index-position);
-}

--- a/packages/axiom-components/src/Position/Position.js
+++ b/packages/axiom-components/src/Position/Position.js
@@ -31,11 +31,6 @@ export default class Position extends Component {
     /** Controls the starting offset of the content */
     offset: PropTypes.oneOf(['start', 'middle', 'end']),
     /**
-     * When provided a mask will be placed behind PositionSource, where this
-     * function is called when clicked.
-     */
-    onMaskClick: PropTypes.func,
-    /**
      * Optional handler that is called, with the new position, when PositionSource
      * has been positioned.
      */
@@ -154,7 +149,7 @@ export default class Position extends Component {
   }
 
   render() {
-    const { children, enabled, isVisible, onMaskClick, showArrow, ...rest } = this.props;
+    const { children, enabled, isVisible, showArrow, ...rest } = this.props;
     const { placement } = this.state;
     const [ position ] = placementToPosition(placement);
 
@@ -176,10 +171,6 @@ export default class Position extends Component {
       enabled && isVisible ? (
         <Portal { ...props } key="portal">
           <div>
-            { onMaskClick && (
-              <div className="ax-position__mask" onClick={ onMaskClick } />
-            ) }
-
             <div className={ classes } ref={ (el) => this._content = el }>
               {
                 cloneElement(findComponent(children, PositionSourceRef), {


### PR DESCRIPTION
**Affected components**
* Dropdown
* AlertDropdown
* Select
* Datepicker

**Background**
The current implementation adds a mask to the DOM when a dropdown is open. This mask captures click events outside of the dropdown and causes the dropdown to be closed. This caused an undesirable double click when navigating between form elements. We wish to remove the mask, removing a click from the users flow.


**Approach**
This PR has proved challenging and I've tried a few different approaches. The one i've settled on is using a custom HOC and disabling pointer events. I could get no other approach to fully meet all the requirements. 
The `onclickoutside` HOC is used to wrap the dropdown source. This adds an event listener to the DOM which is then used to trigger closing of the dropdown. It was necessary to disable clicks, by disabling pointer events, on the dropdown target when the dropdown source is visible. This is to prevent the reopening of the dropdown once closed by a click-away. The mask previously captured this click.

**Deployed Branch here**
https://5b28fca0c965927b31dc9b9e--nostalgic-curie-a20a02.netlify.com/docs/packages/axiom-components/dropdown/