### PR TITLE
feat(DialogBody): Adds option to add display:flex to DialogBody

### DIFF
--- a/packages/axiom-components/src/Dialog/Dialog.css
+++ b/packages/axiom-components/src/Dialog/Dialog.css
@@ -29,6 +29,10 @@
   overflow: auto;
 }
 
+.ax-dialog__body--flex {
+  display: flex;
+}
+
 .ax-dialog__footer {
   padding: 0 var(--page-padding-vertical) var(--page-padding-horizontal);
 }

--- a/packages/axiom-components/src/Dialog/DialogBody.js
+++ b/packages/axiom-components/src/Dialog/DialogBody.js
@@ -1,18 +1,24 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import Base from '../Base/Base';
 
 export default class DialogBody extends Component {
   static propTypes = {
     /** The main content side a Dialog that occupies most of the space */
     children: PropTypes.node,
+    /** Controls if body should be rendered with "display:flex;" */
+    flex: PropTypes.bool,
   };
 
   render() {
-    const { children, ...rest } = this.props;
+    const { children, flex, ...rest } = this.props;
 
+    const classes = classnames('ax-dialog__body', {
+      'ax-dialog__body--flex': flex,
+    });
     return (
-      <Base { ...rest } className="ax-dialog__body">
+      <Base { ...rest } className={ classes }>
         { children }
       </Base>
     );


### PR DESCRIPTION
Adding the option to add "display: flex" to DialogBody to have the possibility to display elements next to each other in the DialogBody. 