### PR TITLE
feat(Add option to change cursor on text input)

### DIFF
--- a/packages/axiom-components/src/Form/InputWrapper.css
+++ b/packages/axiom-components/src/Form/InputWrapper.css
@@ -24,3 +24,7 @@
   position: relative;
   flex-direction: column;
 }
+
+.ax-input__wrapper--target .ax-input {
+  cursor: pointer;
+}

--- a/packages/axiom-components/src/Form/InputWrapper.js
+++ b/packages/axiom-components/src/Form/InputWrapper.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Base from '../Base/Base';
 import './InputWrapper.css';
+import classnames from 'classnames';
 
 const labelSizeMap = {
   small: 'small',
@@ -12,6 +13,7 @@ const labelSizeMap = {
 export default class InputWrapper extends Component {
   static propTypes = {
     children: PropTypes.node,
+    isTarget: PropTypes.bool,
     label: PropTypes.string,
     size: PropTypes.oneOf(['small', 'medium', 'large']),
     space: PropTypes.string,
@@ -23,12 +25,16 @@ export default class InputWrapper extends Component {
   };
 
   render() {
-    const { children, label, size, space, ...rest } = this.props;
+    const { children, isTarget, label, size, space, ...rest } = this.props;
+
+    const classes = classnames('ax-input__wrapper', {
+      'ax-input__wrapper--target': isTarget,
+    });
 
     return (
       <Base { ...rest }
           Component="label"
-          className="ax-input__wrapper"
+          className={ classes }
           space={ space }>
         { label && (
           <Base space="x2" textSize={ labelSizeMap[size] }>

--- a/packages/axiom-components/src/Form/TextInput.css
+++ b/packages/axiom-components/src/Form/TextInput.css
@@ -118,3 +118,7 @@
 .ax-input__button-container {
   display: flex;
 }
+
+.ax-input__wrapper--target {
+  cursor: pointer;
+}

--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -19,6 +19,8 @@ export default class TextInput extends Component {
     error: PropTypes.func,
     /** Applies styling to indicate the users input was invalid */
     invalid: PropTypes.bool,
+    /** Changes the icon to pointer */
+    isTarget: PropTypes.bool,
     /** Descriptive label that is placed with the input field */
     label: PropTypes.string,
     /** Handler for when the input field is blurred */
@@ -89,6 +91,7 @@ export default class TextInput extends Component {
       error,
       valid,
       invalid,
+      isTarget,
       label,
       onClear,
       patterns,
@@ -113,6 +116,7 @@ export default class TextInput extends Component {
       'ax-input__icon-container--invalid': invalid || isValid === false,
     });
 
+
     return (
       <Validate
           error={ error }
@@ -120,7 +124,7 @@ export default class TextInput extends Component {
           required={ required }
           value={ value }>
         { (isValid) =>
-          <InputWrapper label={ label } size={ size } space={ space }>
+          <InputWrapper isTarget={ isTarget } label={ label } size={ size } space={ space }>
             <div className="ax-input__button-container">
               <div className={ classes(isValid) }>
                 { onClear && value ? (

--- a/site/components/Documentation/Resources/Components/Dropdown.js
+++ b/site/components/Documentation/Resources/Components/Dropdown.js
@@ -125,6 +125,7 @@ export default class Documentation extends Component {
               <Dropdown flip="mirror" showArrow={ false }>
                 <DropdownTarget>
                   <TextInput
+                      isTarget
                       onChange={ () => {} }
                       readOnly
                       value={ multiSelection.join(', ') }>


### PR DESCRIPTION
Currently when a `readOnly` `TextInput` is used as a `DropdownTarget` the onHover cursor is a set to `text`. This is confusing as the input is not editable and onClick triggers the dropdown opening. This PR add an option to the `TextInput` to allow the cursor to be set to `pointer` in this situation. 

https://5b2b8489b13fb1210a8fbb0a--president-randy-42828.netlify.com/docs/packages/axiom-components/dropdown