### PR TITLE
feat(Tooltip): Adds boolean delay option

### DIFF
--- a/packages/axiom-components/src/Tooltip/Tooltip.js
+++ b/packages/axiom-components/src/Tooltip/Tooltip.js
@@ -15,6 +15,10 @@ export default class Tooltip extends Component {
      */
     children: PropTypes.node,
     /**
+     * Adds delay to the opening of the tooltip
+     */
+    delay: PropTypes.bool,
+    /**
      * Adds control to enable or disable showing the TooltipSource
      */
     enabled: PropTypes.bool,
@@ -35,6 +39,7 @@ export default class Tooltip extends Component {
   };
 
   static defaultProps = {
+    delay: false,
     enabled: true,
     position: 'top',
   };
@@ -66,12 +71,14 @@ export default class Tooltip extends Component {
   }
 
   render() {
-    const { children, onClick, position, ...rest } = this.props;
+    const { children, delay, onClick, position, ...rest } = this.props;
     const { isVisible } = this.state;
 
     return (
       <Position { ...rest } isVisible={ isVisible } position={ position }>
-        <PositionTarget onClick={ onClick }>{ findComponent(children, TooltipTargetRef) }</PositionTarget>
+        <PositionTarget delay={ delay } onClick={ onClick }>
+          { findComponent(children, TooltipTargetRef) }
+        </PositionTarget>
         <PositionSource>{ findComponent(children, TooltipSourceRef) }</PositionSource>
       </Position>
     );

--- a/packages/axiom-components/src/Tooltip/TooltipTarget.js
+++ b/packages/axiom-components/src/Tooltip/TooltipTarget.js
@@ -2,10 +2,12 @@ import PropTypes from 'prop-types';
 import { Component, cloneElement } from 'react';
 
 export const TooltipTargetRef = 'TooltipTarget';
+const DELAY_TIMEOUT = 1000;
 
 export default class TooltipTarget extends Component {
   static propTypes = {
     children: PropTypes.node,
+    delay: PropTypes.bool,
     onClick: PropTypes.func,
   };
 
@@ -16,19 +18,29 @@ export default class TooltipTarget extends Component {
 
   static typeRef = TooltipTargetRef;
 
-  handleMouseMove(...args) {
-    const { children } = this.props;
+  handleMouseMove(event, ...args) {
+    const { children, delay } = this.props;
     const { showTooltip } = this.context;
     const { onMouseMove = () => {} } = children.props;
 
-    showTooltip();
-    onMouseMove(...args);
+    if (delay && !this.showTimeout) {
+      this.showTimeout = setTimeout(() => showTooltip(), DELAY_TIMEOUT);
+    }
+
+    if (!delay) showTooltip();
+
+    onMouseMove(event, ...args);
   }
 
   handleMouseLeave(...args) {
     const { children } = this.props;
     const { hideTooltip } = this.context;
     const { onMouseLeave = () => {} } = children.props;
+
+    if (this.showTimeout) {
+      clearTimeout(this.showTimeout);
+      this.showTimeout = undefined;
+    }
 
     hideTooltip();
     onMouseLeave(...args);

--- a/packages/axiom-components/src/Tooltip/TooltipTarget.js
+++ b/packages/axiom-components/src/Tooltip/TooltipTarget.js
@@ -18,7 +18,7 @@ export default class TooltipTarget extends Component {
 
   static typeRef = TooltipTargetRef;
 
-  handleMouseMove(event, ...args) {
+  handleMouseMove(...args) {
     const { children, delay } = this.props;
     const { showTooltip } = this.context;
     const { onMouseMove = () => {} } = children.props;
@@ -29,7 +29,7 @@ export default class TooltipTarget extends Component {
 
     if (!delay) showTooltip();
 
-    onMouseMove(event, ...args);
+    onMouseMove(...args);
   }
 
   handleMouseLeave(...args) {

--- a/packages/axiom-components/src/Tooltip/TooltipTarget.js
+++ b/packages/axiom-components/src/Tooltip/TooltipTarget.js
@@ -24,7 +24,7 @@ export default class TooltipTarget extends Component {
     const { onMouseMove = () => {} } = children.props;
 
     if (delay && !this.showTimeout) {
-      this.showTimeout = setTimeout(() => showTooltip(), DELAY_TIMEOUT);
+      this.showTimeout = setTimeout(showTooltip, DELAY_TIMEOUT);
     }
 
     if (!delay) showTooltip();


### PR DESCRIPTION
Gives the option of adding a one second delay to the opening of a tooltip (UX requirement)

https://tooltip-display-delay--andyp-axiom.netlify.com/docs/packages/axiom-components/tooltip