### PR TITLE
fix(Dropdown): Restore pointer events

### DIFF
--- a/packages/axiom-components/src/DataPicker/__snapshots__/DataPicker.test.js.snap
+++ b/packages/axiom-components/src/DataPicker/__snapshots__/DataPicker.test.js.snap
@@ -52,7 +52,6 @@ exports[`DataPicker renders with defaultProps 1`] = `
                 data-ax-at="9c4d25dadaa7"
                 onClick={[Function]}
                 onFocus={[Function]}
-                pointerEventsDisabled={false}
               >
                 <a
                   className="ax-link ax-link--style-body"
@@ -174,7 +173,6 @@ exports[`DataPicker renders with just DataPickerDropdown 1`] = `
                 data-ax-at="9c4d25dadaa7"
                 onClick={[Function]}
                 onFocus={[Function]}
-                pointerEventsDisabled={false}
               >
                 <a
                   className="ax-link ax-link--style-body"
@@ -360,7 +358,6 @@ exports[`DataPicker renders with onSelectColor 1`] = `
                 data-ax-at="9c4d25dadaa7"
                 onClick={[Function]}
                 onFocus={[Function]}
-                pointerEventsDisabled={false}
               >
                 <a
                   className="ax-link ax-link--style-body"
@@ -482,7 +479,6 @@ exports[`DataPicker renders with value 1`] = `
                 data-ax-at="9c4d25dadaa7"
                 onClick={[Function]}
                 onFocus={[Function]}
-                pointerEventsDisabled={false}
               >
                 <a
                   className="ax-link ax-link--style-body"

--- a/packages/axiom-components/src/Dropdown/Dropdown.js
+++ b/packages/axiom-components/src/Dropdown/Dropdown.js
@@ -6,7 +6,9 @@ import PositionSource from '../Position/PositionSource';
 import PositionTarget from '../Position/PositionTarget';
 import { DropdownSourceRef } from './DropdownSource';
 import { DropdownTargetRef } from './DropdownTarget';
+import ReactDOM from 'react-dom';
 
+/* eslint-disable react/no-find-dom-node */
 export default class Dropdown extends Component {
   static propTypes = {
     /**
@@ -42,6 +44,8 @@ export default class Dropdown extends Component {
   static childContextTypes = {
     closeDropdown: PropTypes.func.isRequired,
     openDropdown: PropTypes.func.isRequired,
+    toggleDropdown: PropTypes.func.isRequired,
+    dropdownRef: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -60,7 +64,16 @@ export default class Dropdown extends Component {
     return {
       closeDropdown: () => this.close(),
       openDropdown: () => this.open(),
+      toggleDropdown: () => this.toggle(),
+      dropdownRef: () => this.el,
     };
+  }
+
+  toggle() {
+    if (this.state.isVisible) {
+      return this.close();
+    }
+    this.open();
   }
 
   open() {
@@ -88,11 +101,10 @@ export default class Dropdown extends Component {
           { ...rest }
           isVisible={ isVisible }
           offset={ offset }
-          position={ position }>
+          position={ position }
+          ref={ (el) => this.el = ReactDOM.findDOMNode(el) }>
         <PositionTarget>
-          { React.cloneElement(findComponent(children, DropdownTargetRef), {
-            pointerEventsDisabled: isVisible,
-          } ) }
+          { React.cloneElement(findComponent(children, DropdownTargetRef)) }
         </PositionTarget>
         <PositionSource>{ findComponent(children, DropdownSourceRef) }</PositionSource>
       </Position>

--- a/packages/axiom-components/src/Dropdown/DropdownContext.js
+++ b/packages/axiom-components/src/Dropdown/DropdownContext.js
@@ -34,6 +34,7 @@ export default class DropdownContext extends Component {
 
   static contextTypes = {
     closeDropdown: PropTypes.func.isRequired,
+    dropdownRef: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -55,8 +56,9 @@ export default class DropdownContext extends Component {
     document.addEventListener('mousedown', this.handleClick);
   }
 
-  handleClick() {
-    if (!this.el.contains(event.target)) {
+  handleClick(event) {
+    const dropdownRef = this.context.dropdownRef();
+    if (!dropdownRef.contains(event.target) && !this.el.contains(event.target)) {
       return this.context.closeDropdown();
     }
   }

--- a/packages/axiom-components/src/Dropdown/DropdownTarget.js
+++ b/packages/axiom-components/src/Dropdown/DropdownTarget.js
@@ -10,14 +10,33 @@ export default class DropdownTarget extends Component {
 
   static contextTypes = {
     openDropdown: PropTypes.func.isRequired,
+    toggleDropdown: PropTypes.func.isRequired,
   };
 
   static typeRef = DropdownTargetRef;
 
-  handleOpen(cb, ...args) {
+  constructor(props) {
+    super(props);
+    this.focusEventHasFired = false;
+  }
+
+  handleClick(cb, event) {
+    const { toggleDropdown } = this.context;
+
+    if (this.focusEventHasFired) {
+      this.focusEventHasFired = false;
+      return;
+    }
+
+    toggleDropdown(event);
+    if (cb) cb(event);
+  }
+
+  handleFocus(cb, event) {
     const { openDropdown } = this.context;
-    openDropdown();
-    if (cb) cb(...args);
+    this.focusEventHasFired = true;
+    openDropdown(event);
+    if (cb) cb(event);
   }
 
   render() {
@@ -25,8 +44,8 @@ export default class DropdownTarget extends Component {
 
     return cloneElement(children, {
       ...rest,
-      onClick: this.handleOpen.bind(this, children.props.onClick),
-      onFocus: this.handleOpen.bind(this, children.props.onFocus),
+      onClick: this.handleClick.bind(this, children.props.onClick),
+      onFocus: this.handleFocus.bind(this, children.props.onFocus),
     });
   }
 }


### PR DESCRIPTION
In the work to remove the dropdown mask it was nessacary to disable pointer events from on the Dropdown Target. This was nessacary to avoid the double open bug caused by simultaneous firing of a `focus` & `click` event. 

This cause two problems

1. When the child of the Dropdown target was a DOM element it was being passed the prop `pointerEventsDisabled` this caused an error and did not disable pointer events.

2. On hover affects on the Dropdown target were lost when the dropdown was open.

This PR addresses these issues by replacing the `pointerEventsDisabled` approach with some state within `DropdownTarget` to avoid the double open bug.

Preview
https://5b34b634dd28ef2de9fff4a1--nostalgic-curie-a20a02.netlify.com/docs/packages/axiom-components/dropdown