### PR TITLE
feat(Dropdown): Change context menu focus design

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -144,10 +144,10 @@
 
 .ax-context-menu__item:focus {
   outline: 0;
+  background-color: var(--color-theme-background--hover);
 }
 
-.ax-context-menu__item:hover,
-.ax-context-menu__item:focus {
+.ax-context-menu__item:hover {
   background-color: var(--color-ui-accent--hover);
   color: var(--color-ui-white-noise);
   cursor: pointer;


### PR DESCRIPTION
The current dropdown focus style is very strong and the same as the hover style. This creates confusing states like the one below. I think a good solution would be to make the focus state a little more subtle. 

[Demo](https://5b36373167610c6f1711dd23--nostalgic-curie-a20a02.netlify.com/docs/packages/axiom-components/dropdown)

Old focus style
<img width="286" alt="screen shot 2018-06-29 at 14 39 56" src="https://user-images.githubusercontent.com/3940567/42095728-520478b6-7bab-11e8-96a1-2e7939f063cd.png">



Changed focus style
<img width="250" alt="screen shot 2018-06-29 at 14 48 06" src="https://user-images.githubusercontent.com/3940567/42095767-75fbeb3c-7bab-11e8-9630-b03d2d6e10fd.png">

