### PR TITLE
chore(CI): use git remote with ssh

### DIFF
--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -21,12 +21,15 @@ fi
 git config --global user.email "ci@brandwatch.com"
 git config --global user.name "Brandwatch (via TravisCI)"
 
+# travis sets origin to https. Let set up a second remote for ssh
+git add remote upstream git@github.com:BrandwatchLtd/axiom.git
+
 npm config set "//registry.npmjs.org/:_authToken=\${NPM_API_KEY}"
 
 yarn build:packages
 
 git checkout master
-npx lerna publish --conventional-commits --yes
+npx lerna publish --conventional-commits --yes --git-remote upstream
 
 # Workaround https://github.com/travis-ci/travis-ci/issues/8082
 ssh-agent -k


### PR DESCRIPTION
Travis uses `https://...` as repo url, so the whole ssh key will not even be used 😢 

Another try by adding a remote using the git+ssh and passing that to lerna.
