### PR TITLE
feat(DatePicker): add quick selection

### DIFF
--- a/packages/axiom-components/src/DatePicker/DatePicker.js
+++ b/packages/axiom-components/src/DatePicker/DatePicker.js
@@ -22,14 +22,25 @@ export default class DatePicker extends Component {
     onApply: PropTypes.func,
     /** Callback for when the cancel button has been clicked */
     onCancel: PropTypes.func,
-    /** Callback for when a date or range has been selected */
+    /** Callback for when a date, range with endDate and startDate, or a range
+     * out of rangeSelections has been selected */
     onSelect: PropTypes.func.isRequired,
     /** Whether a date range can be selected */
     rangeSelect: PropTypes.bool,
+    /** Predefined date ranges offered for selection. label will be shown and
+     * range is passed to onSelect when clicked. */
+    rangeSelections: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        range: PropTypes.string.isRequired,
+      }),
+    ),
     /** A single date that appears selected */
     selectedDate: PropTypes.instanceOf(Date),
     /** The date selected at the end of the range */
     selectedEndDate: PropTypes.instanceOf(Date),
+    /** The selected range, specified as it's label */
+    selectedRange: PropTypes.string,
     /** The date selected at the start of the range */
     selectedStartDate: PropTypes.instanceOf(Date),
     /** Configuration for a single date picker view or two pickers side by side */

--- a/packages/axiom-components/src/DatePicker/DatePickerContext.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerContext.js
@@ -2,19 +2,10 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import DropdownContent from '../Dropdown/DropdownContent';
 import DropdownContext from '../Dropdown/DropdownContext';
-import Grid from '../Grid/Grid';
-import GridCell from '../Grid/GridCell';
 import DatePickerControls from './DatePickerControls';
-import DatePickerHeaderControl from './DatePickerHeaderControl';
-import DatePickerViewMonth from './DatePickerViewMonth';
-import {
-  addMonths,
-  dateOrNow,
-  isAfterDay,
-  isBeforeDay,
-  isSameMonth,
-  orderDates,
-} from './utils';
+import DatePickerSelection from './DatePickerSelection';
+import DatePickerRangeSelection from './DatePickerRangeSelection';
+import SelectedDateOrRangePropTypes from './SelectedDateOrRangePropTypes';
 import './DatePicker.css';
 
 export default class DatePickerContext extends Component {
@@ -25,164 +16,71 @@ export default class DatePickerContext extends Component {
     onApply: PropTypes.func,
     onCancel: PropTypes.func,
     onSelect: PropTypes.func.isRequired,
-    rangeSelect: PropTypes.bool,
-    selectedDate: PropTypes.instanceOf(Date),
-    selectedEndDate: PropTypes.instanceOf(Date),
-    selectedStartDate: PropTypes.instanceOf(Date),
+    rangeSelections: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        range: PropTypes.string.isRequired,
+      }),
+    ),
+    selectedRange: PropTypes.string,
     view: PropTypes.string,
+    ...SelectedDateOrRangePropTypes,
   };
 
-  constructor(props) {
-    super(props);
-    this.handleDaySelect = this.handleDaySelect.bind(this);
-
-    const { initialDate, rangeSelect, selectedDate } = this.props;
-    const [ selectedStartDate, selectedEndDate ] = orderDates(
-      this.props.selectedStartDate,
-      this.props.selectedEndDate,
-    );
-
-    const activeStartDate = dateOrNow(
-      (rangeSelect ? selectedStartDate : selectedDate) ||
-      initialDate
-    );
-
-    const activeEndDate = rangeSelect && selectedEndDate
-      ? (isSameMonth(selectedEndDate, selectedStartDate)
-        ? addMonths(selectedEndDate, 1)
-        : selectedEndDate)
-      : addMonths(activeStartDate, 1);
-
-    this.state = {
-      activeStartDate,
-      activeEndDate,
-    };
-  }
-
-  handleActiveStartDateChange(direction) {
-    this.setState((state) => ({
-      activeStartDate: addMonths(state.activeStartDate, direction),
-    }));
-  }
-
-  handleActiveEndDateChange(direction) {
-    this.setState((state) => ({
-      activeEndDate: addMonths(state.activeEndDate, direction),
-    }));
-  }
-
-  handleDaySelect(date) {
+  handleRangeSelection(range) {
     const {
       onSelect,
       rangeSelect,
-      selectedStartDate,
-      selectedEndDate,
     } = this.props;
 
-    if (!rangeSelect) {
-      return onSelect({ date: new Date(date) });
-    }
-
-    if (!selectedStartDate ||
-        isBeforeDay(date, selectedStartDate)) {
-      return onSelect({
-        dateStart: new Date(date),
-        dateEnd: selectedEndDate && new Date(selectedEndDate),
-      });
-    }
-
-    if (!selectedEndDate ||
-        isAfterDay(date, selectedEndDate)) {
-      return onSelect({
-        dateStart: new Date(selectedStartDate),
-        dateEnd: new Date(date),
-      });
-    }
-
-    return onSelect({
-      dateStart: new Date(date),
-      dateEnd: undefined,
-    });
+    rangeSelect && onSelect({ range });
   }
 
   render() {
     const {
-      activeEndDate,
-      activeStartDate,
-    } = this.state;
-
-    const {
       earliestSelectableDate,
       latestSelectableDate,
       rangeSelect,
+      rangeSelections,
       selectedDate,
       selectedEndDate,
+      selectedRange,
       selectedStartDate,
+      onSelect,
       onApply,
       onCancel,
       view,
       ...rest
     } = this.props;
 
-    const [ startDate, endDate ] = orderDates(selectedStartDate, selectedEndDate);
-    const [ earliestDate, latestDate ] = orderDates(earliestSelectableDate, latestSelectableDate);
-
-    const isDoubeView = view === 'double';
+    const showRangeSelection = rangeSelect && rangeSelections && rangeSelections.length;
 
     return (
       <DropdownContext { ...rest }>
         <DropdownContent hasFullSeparator>
-          <Grid responsive={ false } shrink>
-            <GridCell>
-              <DatePickerHeaderControl
-                  date={ activeStartDate }
-                  earliestSelectableDate={ earliestDate }
-                  latestSelectableDate={ isDoubeView
-                    ? addMonths(activeEndDate, -1)
-                    : latestDate }
-                  onNext={ () => this.handleActiveStartDateChange(1) }
-                  onPrevious={ () => this.handleActiveStartDateChange(-1) } />
-              <DatePickerViewMonth
-                  date={ activeStartDate }
-                  earliestSelectableDate={ earliestDate }
-                  latestSelectableDate={ latestDate }
-                  onSelect={ this.handleDaySelect }
-                  rangeSelect={ rangeSelect }
-                  selectedDate={ !rangeSelect ? selectedDate : undefined }
-                  selectedEndDate={ rangeSelect ? endDate : undefined }
-                  selectedStartDate={ rangeSelect ? startDate : undefined } />
-            </GridCell>
-
-            { isDoubeView && (
-              <GridCell hiddenUntil="small">
-                <DatePickerHeaderControl
-                    date={ activeEndDate }
-                    earliestSelectableDate={ addMonths(activeStartDate, 1) }
-                    latestSelectableDate={ latestDate }
-                    onNext={ () => this.handleActiveEndDateChange(1) }
-                    onPrevious={ () => this.handleActiveEndDateChange(-1) } />
-                <DatePickerViewMonth
-                    date={ activeEndDate }
-                    earliestSelectableDate={ earliestDate }
-                    latestSelectableDate={ latestDate }
-                    onSelect={ this.handleDaySelect }
-                    rangeSelect={ rangeSelect }
-                    selectedDate={ !rangeSelect ? selectedDate : undefined }
-                    selectedEndDate={ rangeSelect ? endDate : undefined }
-                    selectedStartDate={ rangeSelect ? startDate : undefined } />
-              </GridCell>
-            ) }
-          </Grid>
-        </DropdownContent>
-
-        <DropdownContent>
+          <DatePickerSelection
+              earliestSelectableDate={ earliestSelectableDate }
+              latestSelectableDate={ latestSelectableDate }
+              onSelect={ onSelect }
+              rangeSelect={ rangeSelect }
+              selectedDate={ selectedDate }
+              selectedEndDate={ selectedEndDate }
+              selectedStartDate={ selectedStartDate }
+              view={ view } />
+          { showRangeSelection && (
+            <DatePickerRangeSelection
+                onRangeSelection={ range => this.handleRangeSelection(range) }
+                rangeSelections={ rangeSelections }
+                selectedRange={ selectedRange }
+                view={ view } />
+          ) }
           <DatePickerControls
               onApply={ onApply }
               onCancel={ onCancel }
               rangeSelect={ rangeSelect }
               selectedDate={ selectedDate }
-              selectedEndDate={ endDate }
-              selectedStartDate={ startDate }
+              selectedEndDate={ selectedEndDate }
+              selectedStartDate={ selectedEndDate }
               view={ view } />
         </DropdownContent>
       </DropdownContext>

--- a/packages/axiom-components/src/DatePicker/DatePickerControls.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerControls.js
@@ -47,7 +47,7 @@ export default class DatePickerControls extends Component {
     } = this.props;
 
     return (
-      <Grid responsive={ false }>
+      <Grid horizontalAlign="end" responsive={ false }>
         { view === 'double' && (
           <GridCell hiddenUntil="small">
             { rangeSelect && selectedStartDate && mediumDate(selectedStartDate) }

--- a/packages/axiom-components/src/DatePicker/DatePickerControls.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerControls.js
@@ -47,9 +47,9 @@ export default class DatePickerControls extends Component {
     } = this.props;
 
     return (
-      <Grid responsive={ false } space="x1">
+      <Grid responsive={ false }>
         { view === 'double' && (
-          <GridCell>
+          <GridCell hiddenUntil="small">
             { rangeSelect && selectedStartDate && mediumDate(selectedStartDate) }
             { rangeSelect && selectedEndDate && ` – ${mediumDate(selectedEndDate)}` }
             { !rangeSelect && selectedDate && mediumDate(selectedDate) }

--- a/packages/axiom-components/src/DatePicker/DatePickerRangeSelection.css
+++ b/packages/axiom-components/src/DatePicker/DatePickerRangeSelection.css
@@ -1,0 +1,45 @@
+.ax-date-range-selection {
+  padding: 0 var(--spacing-grid-size--x2);
+  border-radius: var(--component-round-size-small);
+  background-color: var(--color-theme-background--subtle);
+}
+
+.ax-date-range-selection__item {
+  position: relative;
+  height: var(--component-round-size-small);
+  padding: 0 var(--spacing-grid-size--x2);
+  outline: 0;
+  border: 0;
+  background-color: transparent;
+  color: var(--color-theme-text--subtle);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-loose);
+  text-transform: uppercase;
+  cursor: pointer;
+
+  &:nth-last-child(n+2)::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    width: 0.1875rem;
+    height: 0.1875rem;
+    margin-left: var(--spacing-grid-size--x2);
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    background-color: var(--color-product-deep-thought);
+  }
+
+  &:hover {
+    color: var(--color-ui-accent);
+  }
+
+  &:active {
+    color: var(--color-ui-accent--active);
+  }
+}
+
+.ax-date-range-selection__item--active {
+  color: var(--color-ui-accent);
+  cursor: initial;
+}

--- a/packages/axiom-components/src/DatePicker/DatePickerRangeSelection.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerRangeSelection.js
@@ -1,0 +1,81 @@
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import classnames from 'classnames';
+import Grid from '../Grid/Grid';
+import GridCell from '../Grid/GridCell';
+import Separator from '../Separator/Separator';
+import './DatePickerRangeSelection.css';
+
+export default class DatePickerRangeSelection extends Component {
+  static propTypes = {
+    onRangeSelection: PropTypes.func.isRequired,
+    rangeSelections: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      range: PropTypes.string.isRequired,
+    })).isRequired,
+    selectedRange: PropTypes.string,
+    view: PropTypes.string,
+  };
+
+  render() {
+    const {
+      onRangeSelection,
+      rangeSelections,
+      selectedRange,
+      view,
+    } = this.props;
+
+    const isDoubleView = view === 'double';
+    const rangeSelection = (
+      <div className="ax-date-range-selection">
+        { rangeSelections.map(({ label, range }) => {
+          const classes = classnames('ax-date-range-selection__item', {
+            'ax-date-range-selection__item--active': range === selectedRange,
+          });
+
+          return (
+            <button
+                className={ classes }
+                key={ label }
+                onClick={ () => onRangeSelection(range) }>
+              { label }
+            </button>
+          );
+        }) }
+      </div>
+    );
+
+    if (isDoubleView) {
+      return (
+        <Fragment>
+          <Grid hiddenUntil="small" verticalAlign="middle">
+            <GridCell><Separator /></GridCell>
+            <GridCell none>
+              { rangeSelection }
+            </GridCell>
+            <GridCell><Separator /></GridCell>
+          </Grid>
+          <Grid horizontalAlign="middle" responsive={ false } visibleUntil="small">
+            <GridCell shrink>
+              { rangeSelection }
+            </GridCell>
+            <GridCell full>
+              <Separator />
+            </GridCell>
+          </Grid>
+        </Fragment>
+      );
+    }
+
+    return (
+      <Grid horizontalAlign="middle" responsive={ false }>
+        <GridCell shrink>
+          { rangeSelection }
+        </GridCell>
+        <GridCell full>
+          <Separator />
+        </GridCell>
+      </Grid>
+    );
+  }
+}

--- a/packages/axiom-components/src/DatePicker/DatePickerSelection.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerSelection.js
@@ -1,0 +1,188 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Grid from '../Grid/Grid';
+import GridCell from '../Grid/GridCell';
+import DatePickerHeaderControl from './DatePickerHeaderControl';
+import DatePickerViewMonth from './DatePickerViewMonth';
+import SelectedDateOrRangePropTypes from './SelectedDateOrRangePropTypes';
+import {
+  addMonths,
+  dateOrNow,
+  isAfterDay,
+  isBeforeDay,
+  isSameMonth,
+  orderDates,
+} from './utils';
+import './DatePicker.css';
+
+export default class DatePickerSelection extends Component {
+  static propTypes = {
+    earliestSelectableDate: PropTypes.instanceOf(Date),
+    initialDate: PropTypes.instanceOf(Date),
+    latestSelectableDate: PropTypes.instanceOf(Date),
+    onSelect: PropTypes.func.isRequired,
+    view: PropTypes.string,
+    ...SelectedDateOrRangePropTypes,
+  };
+
+  constructor(props) {
+    super(props);
+    this.handleDaySelect = this.handleDaySelect.bind(this);
+
+    const { initialDate, rangeSelect, selectedDate } = this.props;
+    const [ selectedStartDate, selectedEndDate ] = orderDates(
+      this.props.selectedStartDate,
+      this.props.selectedEndDate,
+    );
+
+    const activeStartDate = dateOrNow(
+      (rangeSelect ? selectedStartDate : selectedDate) ||
+      initialDate
+    );
+
+    const activeEndDate = rangeSelect && selectedEndDate
+      ? (isSameMonth(selectedEndDate, selectedStartDate)
+        ? addMonths(selectedEndDate, 1)
+        : selectedEndDate)
+      : addMonths(activeStartDate, 1);
+
+    this.state = {
+      activeStartDate,
+      activeEndDate,
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    const { selectedDate, selectedStartDate, selectedEndDate, rangeSelect, view } = this.props;
+
+    if (!rangeSelect && selectedDate && !prevProps.selectedDate) {
+      this.setState({ activeStartDate: selectedDate });
+    }
+
+    if (rangeSelect && selectedStartDate !== prevProps.selectedStartDate) {
+      this.setState({ activeStartDate: selectedStartDate });
+    }
+
+    if (rangeSelect && view === 'double' && selectedEndDate !== prevProps.selectedEndDate) {
+      if (isSameMonth(selectedStartDate, selectedEndDate)) {
+        this.setState({ activeEndDate: addMonths(selectedEndDate, 1) });
+      } else {
+        this.setState({ activeEndDate: selectedEndDate });
+      }
+    }
+  }
+
+  handleActiveStartDateChange(direction) {
+    this.setState((state) => ({
+      activeStartDate: addMonths(state.activeStartDate, direction),
+    }));
+  }
+
+  handleActiveEndDateChange(direction) {
+    this.setState((state) => ({
+      activeEndDate: addMonths(state.activeEndDate, direction),
+    }));
+  }
+
+  handleDaySelect(date) {
+    const {
+      onSelect,
+      rangeSelect,
+      selectedStartDate,
+      selectedEndDate,
+    } = this.props;
+
+    if (!rangeSelect) {
+      return onSelect({ date: new Date(date) });
+    }
+
+    if (!selectedStartDate ||
+        isBeforeDay(date, selectedStartDate)) {
+      return onSelect({
+        dateStart: new Date(date),
+        dateEnd: selectedEndDate && new Date(selectedEndDate),
+      });
+    }
+
+    if (!selectedEndDate ||
+        isAfterDay(date, selectedEndDate)) {
+      return onSelect({
+        dateStart: new Date(selectedStartDate),
+        dateEnd: new Date(date),
+      });
+    }
+
+    return onSelect({
+      dateStart: new Date(date),
+      dateEnd: undefined,
+    });
+  }
+
+  render() {
+    const {
+      activeEndDate,
+      activeStartDate,
+    } = this.state;
+
+    const {
+      earliestSelectableDate,
+      latestSelectableDate,
+      rangeSelect,
+      selectedDate,
+      selectedEndDate,
+      selectedStartDate,
+      view,
+    } = this.props;
+
+    const [ startDate, endDate ] = orderDates(selectedStartDate, selectedEndDate);
+    const [ earliestDate, latestDate ] = orderDates(earliestSelectableDate, latestSelectableDate);
+
+    const isDoubleView = view === 'double';
+
+    const activeEndDateOrNextMonth = activeEndDate || addMonths(activeStartDate, 1);
+
+    return (
+      <Grid responsive={ false } shrink>
+        <GridCell>
+          <DatePickerHeaderControl
+              date={ activeStartDate }
+              earliestSelectableDate={ earliestDate }
+              latestSelectableDate={ isDoubleView
+                ? addMonths(activeEndDate, -1)
+                : latestDate }
+              onNext={ () => this.handleActiveStartDateChange(1) }
+              onPrevious={ () => this.handleActiveStartDateChange(-1) } />
+          <DatePickerViewMonth
+              date={ activeStartDate }
+              earliestSelectableDate={ earliestDate }
+              latestSelectableDate={ latestDate }
+              onSelect={ this.handleDaySelect }
+              rangeSelect={ rangeSelect }
+              selectedDate={ !rangeSelect ? selectedDate : undefined }
+              selectedEndDate={ rangeSelect ? endDate : undefined }
+              selectedStartDate={ rangeSelect ? startDate : undefined } />
+        </GridCell>
+
+        { isDoubleView && (
+          <GridCell hiddenUntil="small">
+            <DatePickerHeaderControl
+                date={ activeEndDateOrNextMonth }
+                earliestSelectableDate={ addMonths(activeStartDate, 1) }
+                latestSelectableDate={ latestDate }
+                onNext={ () => this.handleActiveEndDateChange(1) }
+                onPrevious={ () => this.handleActiveEndDateChange(-1) } />
+            <DatePickerViewMonth
+                date={ activeEndDateOrNextMonth }
+                earliestSelectableDate={ earliestDate }
+                latestSelectableDate={ latestDate }
+                onSelect={ this.handleDaySelect }
+                rangeSelect={ rangeSelect }
+                selectedDate={ !rangeSelect ? selectedDate : undefined }
+                selectedEndDate={ rangeSelect ? endDate : undefined }
+                selectedStartDate={ rangeSelect ? startDate : undefined } />
+          </GridCell>
+        ) }
+      </Grid>
+    );
+  }
+}

--- a/packages/axiom-components/src/DatePicker/SelectedDateOrRangePropTypes.js
+++ b/packages/axiom-components/src/DatePicker/SelectedDateOrRangePropTypes.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+
+function isRangeSelect(props) {
+  return !!props.rangeSelect;
+}
+
+function isEmptyOrDate(props, propName) {
+  const value = props[propName];
+
+  if (!value) {
+    return;
+  }
+
+  if (value instanceof Date && !isNaN(value)) {
+    return;
+  }
+
+  return new Error(`Invalid prop ${propName}. Must be a valid Date.`);
+}
+
+export default {
+  rangeSelect: PropTypes.bool,
+  selectedDate: (props, propName) => {
+    if (isRangeSelect(props)) {
+      return;
+    }
+
+    return isEmptyOrDate(props, propName);
+  },
+  selectedEndDate: (props, propName) => {
+    if (!isRangeSelect(props)) {
+      return;
+    }
+
+    return isEmptyOrDate(props, propName);
+  },
+  selectedStartDate: (props, propName) => {
+    if (!isRangeSelect(props)) {
+      return;
+    }
+
+    return isEmptyOrDate(props, propName);
+  },
+};

--- a/site/components/Documentation/Resources/Components/DatePicker.js
+++ b/site/components/Documentation/Resources/Components/DatePicker.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Duration, DateTime } from 'luxon';
 import { Button, ButtonIcon, DatePicker, Grid, GridCell, TextInput, TextInputIcon } from '@brandwatch/axiom-components';
 import {
   DocumentationApi,
@@ -7,33 +8,87 @@ import {
 } from '@brandwatch/axiom-documentation-viewer';
 import { mediumDate } from '@brandwatch/axiom-formatting';
 
+const rangeSelections = [
+  {
+    label: 'Today',
+    range: 'P1D',
+  },
+  {
+    label: '7D',
+    range: 'P7D',
+  },
+  {
+    label: '14D',
+    range: 'P14D',
+  },
+  {
+    label: '1M',
+    range: 'P1M',
+  },
+  {
+    label: '2M',
+    range: 'P2M',
+  },
+];
+
+
 export default class Documentation extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      date: '',
-      dateEnd: '',
-      dateStart: '',
+      date: null,
+      dateEnd: null,
+      dateStart: null,
     };
   }
 
-  render() {
+  handleSelect({ date, dateEnd, dateStart, range }) {
+    if (range) {
+      const end = DateTime.local().endOf('day');
+      dateEnd = end.toJSDate();
+      dateStart = end.minus(Duration.fromISO(range)).plus(1, 'microsecond').toJSDate();
+    }
+
+    this.setState({
+      date,
+      dateEnd,
+      dateStart,
+      range,
+    });
+  }
+
+  getSelectedDateValue() {
     const { date, dateEnd, dateStart } = this.state;
-    const value = dateStart
-    ? `${mediumDate(dateStart)} ${dateEnd ? `- ${mediumDate(dateEnd)}` : ''}`
-    : (date && mediumDate(date));
+
+    if (date) {
+      return mediumDate(date);
+    }
+
+    if (dateStart && dateEnd) {
+      return `${mediumDate(dateStart)} ${dateEnd ? `- ${mediumDate(dateEnd)}` : ''}`;
+    }
+
+    return '';
+  }
+
+  render() {
+    const { date, dateEnd, dateStart, range } = this.state;
 
     return (
       <DocumentationContent>
         <Grid>
           <GridCell>
             <DocumentationShowCase centered>
-              <DatePicker onSelect={ (setValue, getValue, { date, dateStart, dateEnd }) => {
-                setValue('DatePicker', 'selectedDate', date);
-                setValue('DatePicker', 'selectedEndDate', dateEnd);
-                setValue('DatePicker', 'selectedStartDate', dateStart);
-                this.setState({ date, dateEnd, dateStart });
-              } }>
+              <DatePicker
+                  onSelect={ (setValue, getValue, { date, dateStart, dateEnd, range }) => {
+                    this.handleSelect({ date, dateEnd, dateStart, range });
+                  } }
+                  rangeSelect
+                  rangeSelections={ rangeSelections }
+                  selectedDate={ date }
+                  selectedEndDate={ dateEnd }
+                  selectedRange={ range }
+                  selectedStartDate={ dateStart }>
                 <Button>
                   Show Date Picker <ButtonIcon name="chevron-down" />
                 </Button>
@@ -43,16 +98,21 @@ export default class Documentation extends Component {
 
           <GridCell>
             <DocumentationShowCase centered>
-              <DatePicker onSelect={ (setValue, getValue, { date, dateStart, dateEnd }) => {
-                setValue('DatePicker', 'selectedDate', date);
-                setValue('DatePicker', 'selectedEndDate', dateEnd);
-                setValue('DatePicker', 'selectedStartDate', dateStart);
-                this.setState({ date, dateEnd, dateStart });
-              } }>
+              <DatePicker
+                  onSelect={ (setValue, getValue, { date, dateStart, dateEnd, range }) => {
+                    this.handleSelect({ date, dateEnd, dateStart, range });
+                  } }
+                  rangeSelect
+                  rangeSelections={ rangeSelections }
+                  selectedDate={ date }
+                  selectedEndDate={ dateEnd }
+                  selectedRange={ range }
+                  selectedStartDate={ dateStart }
+                  view="double">
                 <TextInput
                     placeholder="Select a date"
                     readOnly
-                    value={ value }>
+                    value={ this.getSelectedDateValue() }>
                   <TextInputIcon align="right" name="chevron-down" />
                 </TextInput>
               </DatePicker>


### PR DESCRIPTION
## Adds quick selection ranges to the Date Picker.

The DatePicker can now offer _quick selections_ for ranges to the user.

These quick selections can be specified by setting the prop `rangeQuickSelections` in the form of e.g. 
```js
[
  {
    label: 'Today',
    range: 'P1D',
  },
  {
    label: '7D',
    range: 'P7D',
  },
  {
    label: '14D',
    range: 'P14D',
  },
  {
    label: '1M',
    range: 'P1M',
  },
  {
    label: '2M',
    range: 'P2M',
  },
]
```

The quick selection ranges are only shown if the component has
* `rangeSelect`
* `rangeQuickSelections` not set to `null` or an empty array.

When the user clicks on of these the `onSelect` callback is called with the `range` of the quick selection clicked.  It's then up to the application to convert the `range` into `startDate` and `endDate` and update these properties on the `DatePicker` so that the clicked range is selected.

This allows us to keep the application logic outside of axiom and keep the implementation completely agnostic of what these ranges mean in an application. (i.e. does 7D means 7*24h ago until now or start of the day 7 days ago until now....)

![single](https://user-images.githubusercontent.com/111471/44025304-088c9110-9ef0-11e8-8ed7-8e59979ee50d.gif)

![double](https://user-images.githubusercontent.com/111471/44025346-2d3b712a-9ef0-11e8-9a96-3eceb1783941.gif)


~~[Netlify Link](https://5b71551b4ed62f6d0c396c7e--youthful-albattani-41ebb2.netlify.com/docs/packages/axiom-components/date-picker)~~
~~[Netlify Link](https://5b72854dc96592106b141531--youthful-albattani-41ebb2.netlify.com/docs/packages/axiom-components/date-picker)~~
~~[Netlify Link](https://5b728f081f12b744b73c03d0--youthful-albattani-41ebb2.netlify.com/docs/packages/axiom-components/date-picker/)~~
[Netlify Link](https://5b87e5191f12b70f1a6bfb06--brandwatch-axiom-tomru.netlify.com/docs/packages/axiom-components/date-picker/)