### PR TITLE
fix(DropdownTarget): Ensures callback property is always fired

### DIFF
--- a/packages/axiom-components/src/Dropdown/DropdownTarget.js
+++ b/packages/axiom-components/src/Dropdown/DropdownTarget.js
@@ -25,10 +25,10 @@ export default class DropdownTarget extends Component {
 
     if (this.focusEventHasFired) {
       this.focusEventHasFired = false;
-      return;
+    } else {
+      toggleDropdown(event);
     }
 
-    toggleDropdown(event);
     if (cb) cb(event);
   }
 


### PR DESCRIPTION
![screen shot 2018-07-11 at 08 58 09](https://user-images.githubusercontent.com/2196085/42558270-99bc5a7a-84e8-11e8-9e93-5b04ce2af0c1.png)

In the screenshot above, the row around the menu button is clickable. If the ellipsis menu is clicked we prevent propagation to stop the row action being triggered.

In the latest version of Axiom the callback doesn't get triggered if the `focusEventHasFired`, making it impossible to stop the propagation.

This fix hopefully addresses that, although I don't have much context as to the recent work in this area, so hopefully it doesn't cause any additional regression.