### PR TITLE
chore(Menu): Update to use new context API

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-hot-loader": "^3.1.3",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
-    "react-test-renderer": "^16.0.0",
+    "react-test-renderer": "^16.4.1",
     "static-site-generator-webpack-plugin": "^3.4.1",
     "style-loader": "^0.13.1",
     "stylelint": "^7.9.0",

--- a/packages/axiom-components/src/Menu/Menu.js
+++ b/packages/axiom-components/src/Menu/Menu.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import omit from 'lodash.omit';
 import Base from '../Base/Base';
+import MenuContext from './MenuContext';
 import './Menu.css';
 
 export default class Menu extends Component {
@@ -12,26 +12,18 @@ export default class Menu extends Component {
     size: PropTypes.oneOf(['medium', 'large']),
   };
 
-  static childContextTypes = {
-    size: PropTypes.string.isRequired,
-  };
-
   static defaultProps = {
     size: 'large',
   };
 
-  getChildContext() {
-    return {
-      size: this.props.size,
-    };
-  }
-
   render() {
-    const { children, ...rest } = this.props;
+    const { children, size, ...rest } = this.props;
 
     return (
-      <Base { ...omit(rest, ['size']) } Component="ul" className="ax-menu">
-        { children }
+      <Base { ...rest } Component="ul" className="ax-menu">
+        <MenuContext.Provider value={ { size } }>
+          { children }
+        </MenuContext.Provider>
       </Base>
     );
   }

--- a/packages/axiom-components/src/Menu/MenuContext.js
+++ b/packages/axiom-components/src/Menu/MenuContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const MenuContext = React.createContext();
+
+export default MenuContext;

--- a/packages/axiom-components/src/Menu/MenuItem.js
+++ b/packages/axiom-components/src/Menu/MenuItem.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import Base from '../Base/Base';
+import MenuContext from './MenuContext';
 
 export default class MenuItem extends Component {
   static propTypes = {
@@ -13,12 +14,7 @@ export default class MenuItem extends Component {
     disabled: PropTypes.bool,
   };
 
-  static contextTypes = {
-    size: PropTypes.string.isRequired,
-  };
-
   render() {
-    const { size } = this.context;
     const { children, active, disabled, ...rest } = this.props;
     const classes = classnames('ax-menu__item', {
       'ax-menu__item--active': active,
@@ -28,18 +24,21 @@ export default class MenuItem extends Component {
     const textSize = {
       medium: 'headtitle',
       large: 'headline',
-    }[size];
+    };
 
     return (
-      <Base
-          Component="li"
-          className={ classes }
-          textSize={ textSize }
-          textStrong>
-        <button { ...rest } className="ax-menu__item-button" disabled={ disabled }>
-          { children }
-        </button>
-      </Base>
+      <MenuContext.Consumer>
+        { (context) => (
+          <Base
+              Component="li"
+              className={ classes }
+              textSize={ textSize[context.size] }
+              textStrong>
+            <button { ...rest } className="ax-menu__item-button" disabled={ disabled }>
+              { children }
+            </button>
+          </Base>) }
+      </MenuContext.Consumer>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7202,6 +7202,10 @@ react-hot-loader@^3.1.3:
     redbox-react "^1.3.6"
     source-map "^0.6.1"
 
+react-is@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
+
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
@@ -7240,13 +7244,22 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0:
+react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-test-renderer@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.1.tgz#f2fb30c2c7b517db6e5b10ed20bb6b0a7ccd8d70"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.4.1"
 
 react-transition-group@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
For discussion.
Example of how we might replace the old react context api with the new one.
Started with a simple example a similar pattern could be used to convert the rest of the components.