### PR TITLE
Remove default color from tip

### DIFF
--- a/packages/axiom-components/src/Context/__snapshots__/Context.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/Context.test.js.snap
@@ -146,7 +146,7 @@ exports[`Context renders with arrowRef 1`] = `
   }
 >
   <div
-    className="ax-tip--top ax-tip--shade-2 ax-tip--shadow"
+    className="ax-tip--top ax-tip--shadow"
   >
     <span
       className="ax-tip__arrow"

--- a/packages/axiom-components/src/Tip/Tip.js
+++ b/packages/axiom-components/src/Tip/Tip.js
@@ -22,7 +22,6 @@ export default class Tip extends Component {
   };
 
   static defaultProps = {
-    color: 'shade-2',
     shadow: true,
     direction: 'top',
   };

--- a/packages/axiom-components/src/Tip/__snapshots__/Tip.test.js.snap
+++ b/packages/axiom-components/src/Tip/__snapshots__/Tip.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Tip renders with arrowRef 1`] = `
 <div
-  className="ax-tip--top ax-tip--shade-2 ax-tip--shadow"
+  className="ax-tip--top ax-tip--shadow"
 >
   <span
     className="ax-tip__arrow"
@@ -22,7 +22,7 @@ exports[`Tip renders with arrowRef 1`] = `
 
 exports[`Tip renders with defaultProps 1`] = `
 <div
-  className="ax-tip--top ax-tip--shade-2 ax-tip--shadow"
+  className="ax-tip--top ax-tip--shadow"
 >
   <span
     className="ax-tip__arrow"
@@ -42,7 +42,7 @@ exports[`Tip renders with defaultProps 1`] = `
 
 exports[`Tip renders with direction bottom 1`] = `
 <div
-  className="ax-tip--bottom ax-tip--shade-2 ax-tip--shadow"
+  className="ax-tip--bottom ax-tip--shadow"
 >
   <span
     className="ax-tip__arrow"
@@ -62,7 +62,7 @@ exports[`Tip renders with direction bottom 1`] = `
 
 exports[`Tip renders with direction left 1`] = `
 <div
-  className="ax-tip--left ax-tip--shade-2 ax-tip--shadow"
+  className="ax-tip--left ax-tip--shadow"
 >
   <span
     className="ax-tip__arrow"
@@ -82,7 +82,7 @@ exports[`Tip renders with direction left 1`] = `
 
 exports[`Tip renders with direction right 1`] = `
 <div
-  className="ax-tip--right ax-tip--shade-2 ax-tip--shadow"
+  className="ax-tip--right ax-tip--shadow"
 >
   <span
     className="ax-tip__arrow"
@@ -102,7 +102,7 @@ exports[`Tip renders with direction right 1`] = `
 
 exports[`Tip renders with direction top 1`] = `
 <div
-  className="ax-tip--top ax-tip--shade-2 ax-tip--shadow"
+  className="ax-tip--top ax-tip--shadow"
 >
   <span
     className="ax-tip__arrow"
@@ -122,7 +122,7 @@ exports[`Tip renders with direction top 1`] = `
 
 exports[`Tip renders with position 1`] = `
 <div
-  className="ax-tip--top ax-tip--shade-2 ax-tip--shadow"
+  className="ax-tip--top ax-tip--shadow"
 >
   <span
     className="ax-tip__arrow"
@@ -146,7 +146,7 @@ exports[`Tip renders with position 1`] = `
 
 exports[`Tip renders without shadow 1`] = `
 <div
-  className="ax-tip--top ax-tip--shade-2"
+  className="ax-tip--top"
 >
   <span
     className="ax-tip__arrow"

--- a/site/components/Documentation/Resources/Components/Tip.js
+++ b/site/components/Documentation/Resources/Components/Tip.js
@@ -12,7 +12,7 @@ export default class Documentation extends Component {
       <DocumentationContent>
         <DocumentationShowCase>
           <Base container>
-            <Tip shadow={ false }>
+            <Tip color="shade-2" shadow={ false }>
               <AlertCard
                   onRemoveClick={ () => {} }
                   shade="shade-2"


### PR DESCRIPTION
- This PR removes the default color from the tip. This introduced a bug into all components that were using Context. 


Here's the deploy branch. : https://5b572ad2e39e7c1d2253a11c--affectionate-mcclintock-42eb2e.netlify.com/