### PR TITLE
fix(Tip): Properly position tip when position is top

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -3,7 +3,6 @@
    * The designs of the tip is 1.5rem from corner to corner. To calculate
    * the pre-rotated square we use `Math.sqrt((1.5rem**2)/2)`
    */
-  --cmp-context-tip-size: 1.0606601717798212rem;
   --cmp-context-tip-space: calc(var(--spacing-grid-size) * 2);
   --cmp-context-padding-small: calc(var(--spacing-grid-size) * 4);
   --cmp-context-padding-large: calc(var(--spacing-grid-size) * 6);

--- a/packages/axiom-components/src/Tip/Tip.css
+++ b/packages/axiom-components/src/Tip/Tip.css
@@ -48,7 +48,7 @@
 }
 
 .ax-tip--top .ax-tip__arrow {
-  transform: translateY(var(--cmp-context-tip-size)) rotate(45deg);
+  transform: translateY(var(--cmp-tip-size)) rotate(45deg);
 }
 
 .ax-tip--right .ax-tip__arrow {


### PR DESCRIPTION
The variable seems to have been off and therefore the tip wasn't positioned correctly when position=top.