### PR TITLE
fix(BarChart): only fade other benchmark lines

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -231,7 +231,7 @@ export default class BarChart extends Component {
                     benchmark={ benchmark }
                     benchmarkHeight={ rowSpace }
                     data={ data[index] }
-                    fadeBenchmarkLine={ isBenchmarkLineFadable && selectedIndex !== null }
+                    fadeBenchmarkLine={ isBenchmarkLineFadable && selectedIndex !== null && selectedIndex !== index }
                     hideBars={ isMultipleValuesData && selectedIndex !== null && selectedIndex !== index }
                     hoverColor={ selectedColor }
                     hoverIndex={ selectedIndex }


### PR DESCRIPTION
Before all benchmark lines where faded out, when you hovered over a bar.

This PR fades out only other benchmark lines, analog to fading out other bars.

Before:
![face-out-benchmark-line-old](https://user-images.githubusercontent.com/111471/43402577-5c8554e2-9413-11e8-97fd-ee6fe242720c.gif)

After:
![face-out-benchmark-line](https://user-images.githubusercontent.com/111471/43402520-380041cc-9413-11e8-80b8-2de3faf6afe0.gif)

[netlify link](https://5b5f19014ed62f5581dd80b7--youthful-albattani-41ebb2.netlify.com/docs/packages/axiom-charts/bar-chart)