### PR TITLE
feat(BarChart): highlight row when mouse is anywhere inside the row

### DIFF
--- a/packages/axiom-charts/src/BarChart/BarChart.js
+++ b/packages/axiom-charts/src/BarChart/BarChart.js
@@ -138,18 +138,38 @@ export default class BarChart extends Component {
     });
   }
 
-  handleMouseEnter(selectedIndex, selectedColor) {
+  handleMouseEnterRow(selectedIndex) {
     this.setState({
-      selectedColor,
       selectedIndex,
     });
   }
 
-  handleMouseLeave() {
+  handleMouseLeaveRow() {
     this.setState(({ isDropdownOpen }) => isDropdownOpen ? {} : ({
-      selectedColor: null,
       selectedIndex: null,
     }));
+  }
+
+  handleMouseEnterBar(selectedIndex, selectedColor) {
+    this.setState({
+      selectedIndex,
+      selectedColor,
+    });
+  }
+
+  handleMouseLeaveBar() {
+    this.setState(({ isDropdownOpen }) => isDropdownOpen ? {} : ({
+      selectedColor: null,
+    }));
+  }
+
+  handleToggleRowVisibility(data, index, hidden) {
+    this.setState({
+      selectedIndex: hidden ? index : null,
+    });
+
+    const { onToggleRowVisibility } = this.props;
+    onToggleRowVisibility && onToggleRowVisibility(data, index);
   }
 
   render() {
@@ -213,10 +233,12 @@ export default class BarChart extends Component {
             <ChartTableRow
                 cloakContainer={ !hidden }
                 hover={ index === selectedIndex }
-                key={ index }>
+                key={ index }
+                onMouseEnter={ () => !hidden && this.handleMouseEnterRow(index) }
+                onMouseLeave={ () => this.handleMouseLeaveRow() } >
               <ChartTableLabel
                   disabled={ hidden }
-                  onToggleRowVisibility={ onToggleRowVisibility && (() => onToggleRowVisibility(data[index], index)) }
+                  onToggleRowVisibility={ () => this.handleToggleRowVisibility(data[index], index, hidden) }
                   textStrong={ index === selectedIndex }
                   width={ labelColumnWidth }>
                 { label }
@@ -242,8 +264,8 @@ export default class BarChart extends Component {
                     lower={ finalLower }
                     onDropdownClose={ () => this.handleDropdonClose() }
                     onDropdownOpen={ (color) => this.handleDropdonOpen(index, color) }
-                    onMouseEnter={ (color) => this.handleMouseEnter(index, color) }
-                    onMouseLeave={ () => this.handleMouseLeave() }
+                    onMouseEnter={ (color) => this.handleMouseEnterBar(index, color) }
+                    onMouseLeave={ () => this.handleMouseLeaveBar() }
                     showBarLabel={ showBarLabel }
                     showDifferenceArea={ showDifferenceArea }
                     singleSelect={ singleSelect }

--- a/packages/axiom-charts/src/BarChart/BarChartBars.js
+++ b/packages/axiom-charts/src/BarChart/BarChartBars.js
@@ -87,8 +87,12 @@ export default class BarChartBars extends Component {
               : hoverColor && color !== hoverColor;
 
             const percent = ((value - lower) / (upper - lower)) * 100;
+
+            const isHoveredByColor = hoverColor && color === hoverColor;
+            const isHoveredByIndex = hoverIndex && index === hoverIndex;
+            const hideLabel = !showBarLabel && !isHoveredByColor && !isHoveredByIndex;
             const labelClasses = classnames('ax-bar-chart__bar-label', {
-              'ax-bar-chart__bar-label--hidden': !(showBarLabel || color === hoverColor),
+              'ax-bar-chart__bar-label--hidden': hideLabel,
             });
 
             const isStretched = benchmarkPercent > percent;

--- a/packages/axiom-charts/src/ChartTable/ChartTable.css
+++ b/packages/axiom-charts/src/ChartTable/ChartTable.css
@@ -66,6 +66,7 @@
   top: 0;
   right: 0;
   bottom: 0;
+  pointer-events: none;
 }
 
 .ax-chart-table__grid-line {


### PR DESCRIPTION
When you hovered over the benchmark line other rows have lost their fade state.

The root cause for this is that the selected row is set when you hover over a bar and the benchmark line is not part of the bar.

This PR fixes this by introducing a separate state, when you hover over the over a row, by just setting `selectedIndex`. When you hover over over a bar the `selectedColor` then set.

This made it possible to keep the other rows faded, when you hovered over the benchmark line.

### Before
![highlight-row-bug](https://user-images.githubusercontent.com/111471/43455605-c322658e-94c0-11e8-927d-52a306758230.gif)

### After
![highlight-row-fix](https://user-images.githubusercontent.com/111471/43455685-00579956-94c1-11e8-92b4-3a8864bb2cae.gif)

(Sorry about the grey background artifacts, seems licecap is bugged out by them when recording the gifs)

~~[netlify link](https://5b603b22b13fb10a278ecf2b--youthful-albattani-41ebb2.netlify.com/docs/packages/axiom-charts/bar-chart)~~

[netlify link](https://5b62f443dd28ef3382c20440--youthful-albattani-41ebb2.netlify.com/docs/packages/axiom-charts/bar-chart)
