### PR TITLE
fix(Reveal): Add check for inner if component is removed before callb…

### DIFF
--- a/packages/axiom-components/src/Reveal/Reveal.js
+++ b/packages/axiom-components/src/Reveal/Reveal.js
@@ -48,11 +48,15 @@ export default class Reveal extends Component {
     }
   }
 
+  componentWillUnmount() {
+    window.cancelAnimationFrame( this._frameId );
+  }
+
   conceal() {
     this.setState({ overflow: 'hidden' });
-    window.requestAnimationFrame(() => {
+    this._frameId = window.requestAnimationFrame(() => {
       this.setState({ height: this.inner.offsetHeight });
-      window.requestAnimationFrame(() => {
+      this._frameId = window.requestAnimationFrame(() => {
         this.setState({ height: 0, opacity: 0 });
       });
     });


### PR DESCRIPTION
In this PR, a check has been added for `inner` which is used to set the height of the `Reveal` component.  This problem was identified during the keyboard navigation in component picker when the reveal component started throwing this exception. 

![screen shot 2018-07-30 at 14 37 02](https://user-images.githubusercontent.com/38217242/43464655-ec092fda-94db-11e8-88ca-088ee4e764f2.png)


It works perfectly if we use mouse click. 
If this solution doesn't sound good, other suggestions are appreciated. 

Deployed Branch: https://5b606c76b3127438e1f38461--affectionate-mcclintock-42eb2e.netlify.com/