### PR TITLE
chore(npmAuth): fix npm config call

### DIFF
--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -24,7 +24,7 @@ git config --global user.name "Brandwatch (via TravisCI)"
 # travis sets origin to https. Let set up a second remote for ssh
 git remote add upstream git@github.com:BrandwatchLtd/axiom.git
 
-npm config set "//registry.npmjs.org/:_authToken=\${NPM_API_KEY}"
+npm config set registry "https://registry.npmjs.org/:_authToken=\${NPM_API_KEY}"
 
 yarn build:packages
 


### PR DESCRIPTION
This is a followup on https://github.com/BrandwatchLtd/axiom/pull/624

The line to set npm config variable was faulty.
- It was missing the config key `registry`
- npm nowadays will throw an error when the protocol is missing

Hope this fixes the publishing 😓 