### PR TITLE
Another attempt to fix publishing

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-node
+lts/carbon

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -24,7 +24,7 @@ git config --global user.name "Brandwatch (via TravisCI)"
 # travis sets origin to https. Let set up a second remote for ssh
 git remote add upstream git@github.com:BrandwatchLtd/axiom.git
 
-npm config set registry "https://registry.npmjs.org/:_authToken=\${NPM_API_KEY}"
+npm config set "//registry.npmjs.org/:_authToken=\${NPM_API_KEY}"
 
 yarn build:packages
 


### PR DESCRIPTION
So did some further testing with a test package, where I could really test publishing without affecting axiom:

|node version|lerna version||
|-|-|-|
|10.7.0|2.8.0| 😢 failed with `lerna ERR! publish Ran out of retries while publishing....` (same error we saw on travis before my "fix")|
|10.7.0|3.0.0-rc.0| 😢 failed with `lerna ERR! yarn publish --ignore-scripts --new-version 0.0.25 --non-interactive exited ENOENT in ...`|
|v8.11.3 (lts/carbon)|2.8.0|🎉publishing works  |

There was already a bug filed for this in https://github.com/lerna/lerna/issues/1515

So
1. reverting https://github.com/BrandwatchLtd/axiom/pull/638 (although not really documented in the docs of `npm config` how it was before is the way to go).
2. use `lts/carbon` in `.nvmrc`

