### PR TITLE
chore(Publishing): Use npm client for publishing with lerna

### DIFF
--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -29,7 +29,7 @@ npm config set "//registry.npmjs.org/:_authToken=\${NPM_API_KEY}"
 yarn build:packages
 
 git checkout master
-npx lerna publish --conventional-commits --yes --git-remote upstream
+npx lerna publish --npm-client npm --conventional-commits --yes --git-remote upstream
 
 # Workaround https://github.com/travis-ci/travis-ci/issues/8082
 ssh-agent -k


### PR DESCRIPTION
Lerna made a switch to use the `npmClient` option for publishing as well as installing, which then use the registry of that npm client, rather that the registry we're setting with the auth token. 

```
lerna ERR! publish error An unexpected error occurred: "https://registry.yarnpkg.com/@brandwatch%2faxiom-components: You must be logged in to publish packages.".
```

This switches back to using the standard `npm` client for publishing ... hopefully this will get it working again.