### PR TITLE
fix(BarChart): fix CombinedBar data prop type

### DIFF
--- a/packages/axiom-charts/src/BarChart/CombinedBar.js
+++ b/packages/axiom-charts/src/BarChart/CombinedBar.js
@@ -13,7 +13,7 @@ export default class CombinedBar extends Component {
     benchmark: PropTypes.number,
     benchmarkPercent: PropTypes.number.isRequired,
     color: PropTypes.string.isRequired,
-    data: PropTypes.array.isRequired,
+    data: PropTypes.object.isRequired,
     label: PropTypes.node.isRequired,
     onDropdownClose: PropTypes.func.isRequired,
     onDropdownOpen: PropTypes.func.isRequired,


### PR DESCRIPTION
`BarChartBars` expects `data` to be a object, which is correct. It passes `data` simply along to `CombinedBar`, hence `CombinedBar` should expect also an object.