### PR TITLE
precise mode in line chart x axis

### DIFF
--- a/packages/axiom-charts/src/ChartLayout/ChartLayout.css
+++ b/packages/axiom-charts/src/ChartLayout/ChartLayout.css
@@ -57,9 +57,14 @@
   position: relative;
 }
 
-.ax-chart-layout__label {
+.ax-chart-layout__y-label {
   position: absolute;
-  transform: translateY(-50%);
+  transform: translateY(50%);
+}
+
+.ax-chart-layout__x-label {
+  position: absolute;
+  transform: translateX(-50%);
 }
 
 .ax-chart-layout__x-labels .ax-chart-layout__label { top: 0; }

--- a/packages/axiom-charts/src/ChartLayout/ChartLayoutLabels.js
+++ b/packages/axiom-charts/src/ChartLayout/ChartLayoutLabels.js
@@ -18,6 +18,11 @@ export default class ChartLayoutLabels extends Component {
     upper: PropTypes.number,
   };
 
+  static defaultProps = {
+    lower: 0,
+    upper: 100,
+  };
+
   render() {
     const { axis, labels, lower, upper, ...rest } = this.props;
     const side = axis === 'y' ? 'bottom' : 'left';

--- a/packages/axiom-charts/src/ChartLayout/ChartLayoutLabels.js
+++ b/packages/axiom-charts/src/ChartLayout/ChartLayoutLabels.js
@@ -20,7 +20,7 @@ export default class ChartLayoutLabels extends Component {
 
   render() {
     const { axis, labels, lower, upper, ...rest } = this.props;
-    const side = axis === 'y' ? 'top' : 'left';
+    const side = axis === 'y' ? 'bottom' : 'left';
     const isPrecise = typeof labels[0].value === 'number';
     const classes = classnames(`ax-chart-layout__${axis}-labels`, {
       'ax-chart-layout__labels--precise': isPrecise,
@@ -39,8 +39,8 @@ export default class ChartLayoutLabels extends Component {
                 <ChartLabel>{ label }</ChartLabel>
               </div>
               <div
-                  className="ax-chart-layout__label"
-                  style={ { [side]: `${100 - ((value - lower) / (upper - lower)) * 100}%` } }>
+                  className={ `ax-chart-layout__${axis}-label` }
+                  style={ { [side]: `${(value - lower) / (upper - lower) * 100}%` } }>
                 <ChartLabel>{ label }</ChartLabel>
               </div>
             </Fragment>

--- a/packages/axiom-charts/src/LineChart/LineChart.js
+++ b/packages/axiom-charts/src/LineChart/LineChart.js
@@ -54,9 +54,13 @@ export default class LineChart extends Component {
     /** Upper value of the data displayed on the chart */
     upper: PropTypes.number,
     /**
-     * Method which returns the labels to be shown along the xAxis, also used to determine where grid lines are drawn
+     * Labels to be shown along the xAxis. Each label contains of a `value`,
+     * defining the position on the xAxis in percent, and an optional `label`.
      */
-    xAxisLabels: PropTypes.func,
+    xAxisLabels: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.node,
+      value: PropTypes.number.isRequired,
+    })),
     /** The title that appears along the xAxis */
     xAxisTitle: PropTypes.node,
     /**
@@ -138,13 +142,12 @@ export default class LineChart extends Component {
     const finalUpper = Math.max(upper, dataUpper);
     const labelMap = chartKey.reduce((map, { color, label, style }) =>
       ({ ...map, [label]: { color, style } }), {});
-    const finalXAxisLabels = xAxisLabels(finalLower, finalUpper);
 
     return (
       <ChartLayout { ...rest }>
         { xAxisTitle && <ChartLayoutTitle axis="x">{ xAxisTitle }</ChartLayoutTitle> }
         { yAxisTitle && <ChartLayoutTitle axis="y">{ yAxisTitle }</ChartLayoutTitle> }
-        { finalXAxisLabels.length > 0 && <ChartLayoutLabels axis="x" labels={ finalXAxisLabels } /> }
+        { xAxisLabels.length > 0 && <ChartLayoutLabels axis="x" labels={ xAxisLabels } /> }
         { yAxisLabels && (
           <ChartLayoutLabels
               axis="y"

--- a/site/components/Documentation/Resources/Charts/LineChart.js
+++ b/site/components/Documentation/Resources/Charts/LineChart.js
@@ -7,7 +7,7 @@ import {
 } from '@brandwatch/axiom-documentation-viewer';
 import DropdownContext from './DropdownContext';
 import TooltipContext from './TooltipContext';
-import { lineChartData, lineChartKey } from './chartData';
+import { lineChartData, lineChartKey, lineChartXAxisLabels } from './chartData';
 
 export default class Documentation extends Component {
   render() {
@@ -22,21 +22,7 @@ export default class Documentation extends Component {
               height="12rem"
               lower={ 0 }
               upper={ 30 }
-              xAxisLabels={ () => [
-                'Dec 1',
-                'Dec 3',
-                'Dec 5',
-                'Dec 7',
-                'Dec 9',
-                'Dec 11',
-                'Dec 13',
-                'Dec 15',
-                'Dec 17',
-                'Dec 19',
-                'Dec 21',
-                'Dec 23',
-                'Dec 25',
-              ] }
+              xAxisLabels={ () => lineChartXAxisLabels }
               xAxisTitle="Previous 30 days"
               yAxisLabels={ [
                 { label: '0M', value: 0 },

--- a/site/components/Documentation/Resources/Charts/LineChart.js
+++ b/site/components/Documentation/Resources/Charts/LineChart.js
@@ -22,7 +22,7 @@ export default class Documentation extends Component {
               height="12rem"
               lower={ 0 }
               upper={ 30 }
-              xAxisLabels={ () => lineChartXAxisLabels }
+              xAxisLabels={ lineChartXAxisLabels }
               xAxisTitle="Previous 30 days"
               yAxisLabels={ [
                 { label: '0M', value: 0 },

--- a/site/components/Documentation/Resources/Charts/chartData.js
+++ b/site/components/Documentation/Resources/Charts/chartData.js
@@ -192,6 +192,12 @@ export const lineChartData = [{
   values: [7, 7, 14, 7, 8, 7, 6, 9, 15, 11, 12, 8, 2, 7, 16, 9, 17, 18, 23, 17, 21, 12, 13, 14, 15, 18, 14],
 }];
 
+/* Data points for Dec 1st until Dec 27th. Create labels for every 2nd day */
+export const lineChartXAxisLabels = Array(14).fill(null).map((_, index) => ({
+  label: `Dec ${ 1 + index * 2 }`,
+  value: index * 100 / 13,
+}));
+
 export const sparkLineBenchmark = 10;
 
 export const sparkLineData = [{


### PR DESCRIPTION
## Background

`LineChart` uses `ChartLayoutLabels` to position the labels on the x- and y-axis. 

On the y-axis it supports the [`precise mode`](https://github.com/BrandwatchLtd/axiom/blob/master/packages/axiom-charts/src/ChartLayout/ChartLayoutLabels.js#L33), i.e. you specify the exact position with 
```js
[
  {
    label: <text>,
    value: <number>,
  },
  ...
]
```

The value is then converted, based on `upper` and `lower`, to the range of `0-100%`.

For the x-axis the `precise mode` is not supported. Instead the passed labels are [positioned with flexbox](https://github.com/BrandwatchLtd/axiom/blob/8c021a1f5aee0443756efc3e9fd9a6b39e76a945/packages/axiom-charts/src/ChartLayout/ChartLayout.css#L30-L31). Though that seems wrong as
* it enforces the consumer to use labels, that match the positioning of flexbox
* positioning with `justify-content: space-around` never aligns with the chart, even when you pass `n-2` labels for `n` data points (the line is always drawn from position 0% to 100%)

![image](https://user-images.githubusercontent.com/111471/44665638-b6f03c80-aa16-11e8-9db1-32bb24324dc9.png)

Perhaps I'm lacking the use-case for the positioning with flex-box ?

Nevertheless, I'd like to enable the `precise mode` in this PR on the x-axis, as then a consumer is then free to position the labels, instead of matching the labels to the internal positioning by axiom.

It's not yet defined what the domain of the x-axis could be. It does not have an upper or lower limit, nor is it bound to be just numeric - time is a quite common use-case (see benchmark component).

The line does not really care about the domain of the x-axis, as it simply spreads all data points equally, beginning with position `0%` up to `100%` for the last data point.

Instead of introducing another `upper` and `lower` for the x-axis I'm proposing to position in the domain used by the line already `0-100%`. 

## Changes in this PR

* labels of the y-axis were positioned from the top, hence with `${100-normalizedValue}`. I switched that, so both axis can be positioned relative the the origin (lower left corner, being 0%,0%)
* `lower` and `upper` are not passed to `ChartLayoutLabels` for the x-axis. Define them as `0%`, `100%` in the default props.
* update the example with aligned x-axis labels

## not tackled inside this PR

* non-precise mode, as I'm unsure if I missed a use-case and will not remove it until discussed

## Visuals
![image](https://user-images.githubusercontent.com/111471/44666850-9a093880-aa19-11e8-8a35-1d5d098579ae.png)

[Netlify](https://5b84114b67610c267eeed09a--youthful-albattani-41ebb2.netlify.com/docs/packages/axiom-charts/line-chart)

The example has a data point for each day, from Dec 1st to Dec 27th, and labels for each second day.
