### PR TITLE
fix(Dropdown): Implement native style hover and focus

### DIFF
--- a/packages/axiom-components/package.json
+++ b/packages/axiom-components/package.json
@@ -13,6 +13,7 @@
     "@brandwatch/axiom-materials": "^1.6.0",
     "@brandwatch/axiom-utils": "^0.1.11",
     "classnames": "^2.2.1",
+    "element-closest": "^2.0.2",
     "lodash.omit": "^4.5.0",
     "luxon": "^1.3.1",
     "popper.js": "^1.12.5",

--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -126,10 +126,6 @@
 
 .ax-context-menu__item:focus {
   outline: 0;
-}
-
-.ax-context-menu__item:hover,
-.ax-context-menu__item:focus {
   background-color: var(--color-ui-accent--hover);
   color: var(--color-ui-white-noise);
   cursor: pointer;

--- a/packages/axiom-components/src/Dropdown/DropdownContext.js
+++ b/packages/axiom-components/src/Dropdown/DropdownContext.js
@@ -5,6 +5,10 @@ import omit from 'lodash.omit';
 import Context from '../Context/Context';
 import { contextMenuItemSelector } from '../Context/ContextMenuItem';
 
+if (typeof window !== 'undefined') {
+  require('element-closest');
+}
+
 const isFocusableMenuItem = (element) =>
   element && element.hasAttribute(contextMenuItemSelector) &&
     !element.disabled;
@@ -41,6 +45,7 @@ export default class DropdownContext extends Component {
     super(props);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleClick = this.handleClick.bind(this);
+    this.handleMouseMove = this.handleMouseMove.bind(this);
   }
 
   componentWillMount() {
@@ -50,10 +55,12 @@ export default class DropdownContext extends Component {
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleKeyDown);
     document.removeEventListener('mousedown', this.handleClick);
+    document.removeEventListener('mousemove', this.handleMouseMove);
   }
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClick);
+    document.addEventListener('mousemove', this.handleMouseMove);
   }
 
   handleClick(event) {
@@ -69,6 +76,18 @@ export default class DropdownContext extends Component {
 
   getMenuItems() {
     return [...this.el.querySelectorAll(`[${contextMenuItemSelector}]:not(:disabled)`)];
+  }
+
+  focusMenuItem(element) {
+    const menuItem = element.closest(`[${contextMenuItemSelector}]`);
+
+    if (menuItem && isFocusableMenuItem(menuItem)) {
+      menuItem.focus();
+    }
+  }
+
+  handleMouseMove(event) {
+    this.focusMenuItem(event.target);
   }
 
   handleKeyDown(event) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,6 +2772,10 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   version "1.3.33"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz#bf00703d62a7c65238136578c352d6c5c042a545"
 
+element-closest@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-2.0.2.tgz#72a740a107453382e28df9ce5dbb5a8df0f966ec"
+
 elliptic@^6.0.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"


### PR DESCRIPTION
Related ticket: [AX-53](https://office.brandwatch.com/jira/browse/AX-53)
Fixes: [TOP-853](https://office.brandwatch.com/jira/browse/TOP-853) & [STS-160](https://office.brandwatch.com/jira/browse/STS-160)

##### Menus in a Dropdown now have the same hover and focus styles as a native select menus.

[Netlify](https://5b8eb280dd28ef7b7f4716af--priceless-benz-91b798.netlify.com/docs/packages/axiom-components/dropdown)

Previously hover and focus styles were separate and you could get into a state where both were bing applied on two menu items. Now the blue highlight can only be applied to a single item even when switching between mouse and keyboard menu navigation.

old:
![e8nl9cv6h2](https://user-images.githubusercontent.com/856071/44721388-aba61b00-aac1-11e8-85cc-eee89985e335.gif)

new:
![cnuyiwdzzc](https://user-images.githubusercontent.com/856071/44721455-ddb77d00-aac1-11e8-84c7-d8460f42c868.gif)
