### PR TITLE
fix(babel-plugin-axiom-imports): Member expression literals transform

### DIFF
--- a/packages/babel-plugin-axiom-imports/src/__snapshots__/babel-plugin-axiom-imports.test.js.snap
+++ b/packages/babel-plugin-axiom-imports/src/__snapshots__/babel-plugin-axiom-imports.test.js.snap
@@ -111,6 +111,21 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 console.log(_axiomMaterials2.default.colors); /* eslint-disable no-console */"
 `;
 
+exports[`babelPluginAxiom property access 1`] = `
+"'use strict';
+
+var _colors = require('@brandwatch/axiom-materials/dist/colors');
+
+var _ = _interopRequireWildcard(_colors);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+console.log(_.foo); /* eslint-disable no-console */
+
+console.log(_['foo']);
+console.log(_['foo-bar']);"
+`;
+
 exports[`babelPluginAxiom scoped imports 1`] = `
 "'use strict';
 

--- a/packages/babel-plugin-axiom-imports/src/babel-plugin-axiom-imports.js
+++ b/packages/babel-plugin-axiom-imports/src/babel-plugin-axiom-imports.js
@@ -70,8 +70,7 @@ module.exports = ({ types }) => {
 
       MemberExpression(path) {
         if (matchesAxiomExport(path, path.node.object.name)) {
-          const { type, name } = importAxiom(specified[path.node.object.name], path.hub.file);
-          path.replaceWith(types.memberExpression({ type, name }, types.identifier(path.node.property.name)));
+          path.node.object.name = importAxiom(specified[path.node.object.name], path.hub.file).name;
         }
       },
 

--- a/packages/babel-plugin-axiom-imports/src/babel-plugin-axiom-imports.test.js
+++ b/packages/babel-plugin-axiom-imports/src/babel-plugin-axiom-imports.test.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import { transformFileSync } from 'babel-core';
 import babelPluginAxiom from './babel-plugin-axiom-imports';
+import babelPluginTransformSvgAxiom from '../../babel-plugin-transform-svg-axiom';
 
 describe('babelPluginAxiom', () => {
   test('aliased imports', () => {
@@ -36,6 +37,12 @@ describe('babelPluginAxiom', () => {
   test('scoped imports', () => {
     expect(transformFileSync(path.resolve(__dirname, '../test/scoped.js'), {
       plugins: [babelPluginAxiom],
+    }).code).toMatchSnapshot();
+  });
+
+  test('property access', () => {
+    expect(transformFileSync(path.resolve(__dirname, '../test/property.js'), {
+      plugins: [babelPluginTransformSvgAxiom, babelPluginAxiom],
     }).code).toMatchSnapshot();
   });
 });

--- a/packages/babel-plugin-axiom-imports/test/property.js
+++ b/packages/babel-plugin-axiom-imports/test/property.js
@@ -1,0 +1,7 @@
+/* eslint-disable no-console */
+
+import { colors } from '@brandwatch/axiom-materials';
+
+console.log(colors.foo);
+console.log(colors['foo']);
+console.log(colors['foo-bar']);


### PR DESCRIPTION
The import plugin was incorrectly stripping the string literal property accessors, when transform object names (from imports). 

This was breaking the icons because inside the Icon component there was this ....

```js
if (icons[name]) {
  return null;
}
```
Which was incorrectly changed to...

```js
if (!_icons2.default.name) {
  return null;
}
````

Now changes it to...
```js
if (!_icons2.default[name]) {
  return null;
}
```