### PR TITLE
Fix input container spacing

### DIFF
--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -69,6 +69,7 @@ export default class TextInput extends Component {
 
   static defaultProps = {
     size: 'medium',
+    space: 'x4',
     type: 'text',
   };
 
@@ -131,7 +132,7 @@ export default class TextInput extends Component {
           required={ required }
           value={ value }>
         { (isValid) =>
-          <div className="ax-input__container">
+          <Base className="ax-input__container" space={ space }>
             <InputWrapper
                 disabled={ disabled }
                 hasFocus={ hasFocus }
@@ -140,7 +141,6 @@ export default class TextInput extends Component {
                 isValid={ isValid }
                 label={ label }
                 size={ size }
-                space={ space }
                 style={ style }
                 usageHint={ usageHint }
                 usageHintPosition={ usageHintPosition }
@@ -169,7 +169,7 @@ export default class TextInput extends Component {
               }
             </InputWrapper>
             { button }
-          </div>
+          </Base>
         }
       </Validate>
     );

--- a/packages/axiom-components/src/Form/__snapshots__/TextInput.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/TextInput.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TextInput renders when disabled 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -25,7 +25,7 @@ exports[`TextInput renders when disabled 1`] = `
 
 exports[`TextInput renders when invalid 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -48,7 +48,7 @@ exports[`TextInput renders when invalid 1`] = `
 
 exports[`TextInput renders when valid 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -71,7 +71,7 @@ exports[`TextInput renders when valid 1`] = `
 
 exports[`TextInput renders with TextInputButton 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -104,7 +104,7 @@ exports[`TextInput renders with TextInputButton 1`] = `
 
 exports[`TextInput renders with TextInputIcon 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -146,7 +146,7 @@ exports[`TextInput renders with TextInputIcon 1`] = `
 
 exports[`TextInput renders with defaultProps 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -169,7 +169,7 @@ exports[`TextInput renders with defaultProps 1`] = `
 
 exports[`TextInput renders with label 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -201,7 +201,7 @@ exports[`TextInput renders with label 1`] = `
 
 exports[`TextInput renders with onClear and value 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -248,7 +248,7 @@ exports[`TextInput renders with onClear and value 1`] = `
 
 exports[`TextInput renders with size large 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -271,7 +271,7 @@ exports[`TextInput renders with size large 1`] = `
 
 exports[`TextInput renders with size medium 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -294,7 +294,7 @@ exports[`TextInput renders with size medium 1`] = `
 
 exports[`TextInput renders with size small 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"

--- a/packages/axiom-components/src/Select/__snapshots__/Select.test.js.snap
+++ b/packages/axiom-components/src/Select/__snapshots__/Select.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Select renders with a selected value 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"
@@ -46,7 +46,7 @@ exports[`Select renders with a selected value 1`] = `
 
 exports[`Select renders with defaultProps 1`] = `
 <div
-  className="ax-input__container"
+  className="ax-input__container ax-space--x4"
 >
   <label
     className="ax-input__wrapper ax-space--x4"

--- a/site/components/Documentation/Resources/Components/Form.js
+++ b/site/components/Documentation/Resources/Components/Form.js
@@ -29,6 +29,10 @@ export default class Documentation extends Component {
                   onChange={ (setValue, getValue, event) => setValue('TextInput', 'value', event.target.value) }
                   placeholder="Write in me"
                   size="medium"/>
+              <TextInput
+                  onChange={ (setValue, getValue, event) => setValue('TextInput', 'value', event.target.value) }
+                  placeholder="Write in me"
+                  size="medium"/>
             </DocumentationShowCase>
           </GridCell>
 
@@ -70,7 +74,6 @@ export default class Documentation extends Component {
           </GridCell>
         </Grid>
 
-
         <DocumentationApi components={ [
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Form/TextInput'),
           require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Form/TextInputButton'),
@@ -78,6 +81,10 @@ export default class Documentation extends Component {
         ] } />
 
         <DocumentationShowCase>
+          <TextArea
+              label="Lorem ipsum"
+              placeholder="Write in me"
+              usageHint="This is a usage hint" />
           <TextArea
               label="Lorem ipsum"
               placeholder="Write in me"


### PR DESCRIPTION
This fixes an issue that was introduced in 4.11.0 (https://github.com/HHogg/axiom/commit/bc3072c) where because the inputWrapper was moved inside of the TextInput's input container, the bottom-margin of `ax-space--x4` would no longer appear as it would always be the last child.

This adds a `space` property to the TextInput's container to rectify this. 

I've also made it so the documentation showcases for TextInputs and TextAreas now have at least one case of two inputs in a showcase area so that it is easier to notice these issues in development