### PR TITLE
Support className on `Grid` and `GridCell`

### DIFF
--- a/packages/axiom-components/src/Grid/Grid.js
+++ b/packages/axiom-components/src/Grid/Grid.js
@@ -8,6 +8,8 @@ export default class Grid extends Component {
   static propTypes = {
     /** <GridCells>. */
     children: PropTypes.node,
+    /** Class name to be appended to the element */
+    className: PropTypes.string,
     /**
      * Applies fill styling for all GridCell children.
      * See GridCell for fill explanation
@@ -61,6 +63,7 @@ export default class Grid extends Component {
   render() {
     const {
       children,
+      className,
       fill,
       fit,
       full,
@@ -93,7 +96,7 @@ export default class Grid extends Component {
       [`ax-grid--vertical-${verticalAlign}`]: verticalAlign,
       [`ax-grid--horizontal-${horizontalAlign}`]: horizontalAlign,
       'ax-grid--wrap': wrap === true,
-    });
+    }, className);
 
     return (
       <Base space="x6" { ...rest } className="ax-grid__container">

--- a/packages/axiom-components/src/Grid/Grid.test.js
+++ b/packages/axiom-components/src/Grid/Grid.test.js
@@ -16,6 +16,12 @@ describe('Grid', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders with className', () => {
+    const component = getComponent({ className: 'foo' });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders with responsive false', () => {
     const component = getComponent({ responsive: false });
     const tree = component.toJSON();

--- a/packages/axiom-components/src/Grid/GridCell.js
+++ b/packages/axiom-components/src/Grid/GridCell.js
@@ -6,6 +6,8 @@ import Base from '../Base/Base';
 export default class GridCell extends Component {
   static propTypes = {
     children: PropTypes.node,
+    /** Class name to be appended to the element */
+    className: PropTypes.string,
     /**
      * Sizes itself according to the size of its contents. This causes the grid
      * to attempt to evenly distribute the cells, but allows cells to increase
@@ -64,6 +66,7 @@ export default class GridCell extends Component {
   render() {
     const {
       children,
+      className,
       fill,
       fit,
       full,
@@ -88,7 +91,7 @@ export default class GridCell extends Component {
       [`ax-grid__cell--none--${none}`]: none && none !== true,
       [`ax-grid__cell--shrink--${shrink}`]: shrink && shrink !== true,
       'ax-grid__cell--sub-grid': subGrid,
-    });
+    }, className);
 
     const styles = {
       width: width && `${Math.max(0, Math.min(width, 100))}%`,

--- a/packages/axiom-components/src/Grid/GridCell.test.js
+++ b/packages/axiom-components/src/Grid/GridCell.test.js
@@ -16,6 +16,12 @@ describe('GridCell', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders with className', () => {
+    const component = getComponent({ className: 'foo' });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   describe('renders with fill', () => {
     [true, 'small', 'medium', 'large'].forEach((fill) => {
       it(fill, () => {

--- a/packages/axiom-components/src/Grid/__snapshots__/Grid.test.js.snap
+++ b/packages/axiom-components/src/Grid/__snapshots__/Grid.test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Grid renders with className 1`] = `
+<div
+  className="ax-grid__container ax-space--x6"
+>
+  <div
+    className="ax-grid ax-grid--responsive ax-grid--gutters-horizontal--medium ax-grid--gutters-vertical--medium ax-grid--wrap foo"
+  >
+    <div />
+  </div>
+</div>
+`;
+
 exports[`Grid renders with defaultProps 1`] = `
 <div
   className="ax-grid__container ax-space--x6"

--- a/packages/axiom-components/src/Grid/__snapshots__/GridCell.test.js.snap
+++ b/packages/axiom-components/src/Grid/__snapshots__/GridCell.test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GridCell renders with className 1`] = `
+<div
+  className="ax-grid__cell foo"
+  style={
+    Object {
+      "width": undefined,
+    }
+  }
+>
+  <div />
+</div>
+`;
+
 exports[`GridCell renders with defaultProps 1`] = `
 <div
   className="ax-grid__cell"


### PR DESCRIPTION
Following scenario. 

I want to create a table using Axiom Grid. The table consist of two columns ID and name. The ID column needs to have a background image. Axiom doesn't except the `className` property for `GridCell` which is the reason why I added a `div` as a children of `GridCell`. Not very nice, but it works. 


```js
<Grid>
    <GridCell>
        <Grid>
            <GridCell>
                <div className="pattern-background">2</div>
            </GridCell>
            <GridCell>Smith</GridCell>
        </Grid>
    </GridCell>
    <GridCell>
        <Grid>
            <GridCell>
                <div className="pattern-background">3</div>
            </GridCell>
            <GridCell>Williams</GridCell>
        </Grid>
    </GridCell>
    <GridCell>
        <Grid>
            <GridCell>
                <div className="pattern-background">5</div>
            </GridCell>
            <GridCell>Rodriguez</GridCell>
        </Grid>
    </GridCell>
</Grid>
```

However, now there is this other requirement that the last row should not have a background image. I don't want to do this programmatically and would prefer using css for that and here the problem starts.

I can not rely on Axiom class names because they can change without notice. Therefore I would like to be able to add additional classes for `Grid` and `GridCell` so I can write use Axiom like that



```js
<Grid>
    <GridCell className="table-row">
        <Grid>
            <GridCell className="pattern-background">2</GridCell>
            <GridCell>Smith</GridCell>
        </Grid>
    </GridCell>
    <GridCell className="table-row">
        <Grid>
            <GridCell className="pattern-background">3</GridCell>
            <GridCell>Williams</GridCell>
        </Grid>
    </GridCell>
    <GridCell className="table-row">
        <Grid>
            <GridCell className="pattern-background">5</GridCell>
            <GridCell>Rodriguez</GridCell>
        </Grid>
    </GridCell>
</Grid>
```

```css

.table-row:last-child .pattern-background {
    background: none;
}

```
