### PR TITLE
fix(TextInput): Add ability to focus TextInput in axiom.

### DIFF
--- a/packages/axiom-components/src/Base/Base.js
+++ b/packages/axiom-components/src/Base/Base.js
@@ -19,6 +19,8 @@ export default class Base extends Component {
       PropTypes.string,
       PropTypes.func,
     ]),
+    /** Pass this prop to get ref to the Base Component instance. */
+    baseRef: PropTypes.object,
     /** Class name to be appended to the element */
     className: PropTypes.string,
     /** Adds ability to make an element invisible */
@@ -161,6 +163,7 @@ export default class Base extends Component {
       textUnderline,
       theme,
       visibleUntil,
+      baseRef,
       ...rest
     } = this.props;
 
@@ -202,7 +205,7 @@ export default class Base extends Component {
     }
 
     return (
-      <Component { ...rest } className={ classes } />
+      <Component { ...rest } className={ classes } ref={ baseRef } />
     );
   }
 }

--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+
 import { findComponent } from '@brandwatch/axiom-utils';
 import Base from '../Base/Base';
 import Validate from '../Validation/Validate';
@@ -17,6 +18,8 @@ export default class TextInput extends Component {
     disabled: PropTypes.bool,
     /** See Validate[error] */
     error: PropTypes.func,
+    /** Pass this prop to get ref to the Text Component instance. */
+    inputRef: PropTypes.object,
     /** Applies styling to indicate the users input was invalid */
     invalid: PropTypes.bool,
     /** Adds a progress indicator the the right of the text input */
@@ -116,6 +119,7 @@ export default class TextInput extends Component {
       usageHint,
       usageHintPosition,
       value,
+      inputRef,
       ...rest
     } = this.props;
 
@@ -154,6 +158,7 @@ export default class TextInput extends Component {
               { !showOnClear && showIcon && icon }
               <Base { ...rest }
                   Component="input"
+                  baseRef={ inputRef }
                   className="ax-input"
                   disabled={ disabled }
                   onBlur={ this.handleOnBlur.bind(this) }


### PR DESCRIPTION
This PR adds the ability to focus TextInput in axiom. This is to avoid looking for the `input` tag and using `findDOMNode` in every app that uses `TextInput` and instead providing a way to do this in axiom.  