### PR TITLE
feat(ContextMenuItem): stop multiselect mode triggering onClick 3 times

### DIFF
--- a/packages/axiom-components/src/Context/ContextMenuItem.js
+++ b/packages/axiom-components/src/Context/ContextMenuItem.js
@@ -43,7 +43,12 @@ export default class ContextMenuItem extends Component {
           textStrong={ selected }>
         { multiSelect && (
           <div className="ax-context-menu__item-checkbox">
-            <CheckBox checked={ selected } disabled={ disabled } indeterminate={ indeterminate } onChange={ onClick } />
+            <CheckBox
+                checked={ selected }
+                disabled={ disabled }
+                indeterminate={ indeterminate }
+                onChange={ onClick }
+                onClick={ e => e.stopPropagation() }/>
           </div>
         ) }
 

--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
@@ -69,6 +69,7 @@ exports[`ContextMenuItem renders with multiSelect 1`] = `
   >
     <label
       className="ax-checkbox ax-space--x2"
+      onClick={[Function]}
     >
       <input
         checked={false}
@@ -98,6 +99,7 @@ exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
   >
     <label
       className="ax-checkbox ax-space--x2"
+      onClick={[Function]}
     >
       <input
         checked={true}
@@ -128,6 +130,7 @@ exports[`ContextMenuItem renders with multiSelect and title 1`] = `
   >
     <label
       className="ax-checkbox ax-space--x2"
+      onClick={[Function]}
     >
       <input
         checked={false}


### PR DESCRIPTION
BREAKING CHANGE: ContextMenuItem's onClick event now stops Propagation.

https://office.brandwatch.com/jira/browse/AX-109

There may have been multiselect dropdowns with their onClicks built to account for this. Now that the event doesn't trigger three times when clicking the checkbox, there may be unintended side effects 