### PR TITLE
feat(TextInput): Add "number" option to type prop.

### DIFF
--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -52,7 +52,7 @@ export default class TextInput extends Component {
     /** Visual style variations of the input field */
     style: PropTypes.oneOf(['overlay']),
     /** Type of the input field */
-    type: PropTypes.oneOf(['password', 'text']),
+    type: PropTypes.oneOf(['password', 'text', 'number']),
     /**
      * Specifies text to be used in the form element's usage hint that is
      * displayed in a tooltip coming off a question mark in the top right


### PR DESCRIPTION
This PR adds a number type option to the `TextInput` component, allowing us to use HTML number fields.