### PR TITLE
feat(Base): Enable "sentiment-positive/negative/neutral" as textColor

### DIFF
--- a/packages/axiom-components/src/Base/Base.js
+++ b/packages/axiom-components/src/Base/Base.js
@@ -93,6 +93,9 @@ export default class Base extends Component {
       'rocky-planet',
       'deep-thought',
       'luna-dust',
+      'sentiment-negative',
+      'sentiment-positive',
+      'sentiment-neutral',
     ]),
     /** Text ellipsis styling */
     textEllipsis: PropTypes.bool,

--- a/packages/axiom-components/src/Typography/Text.css
+++ b/packages/axiom-components/src/Typography/Text.css
@@ -65,6 +65,9 @@
 .ax-text--color-rocky-planet { color: var(--color-product-rocky-planet); }
 .ax-text--color-deep-thought { color: var(--color-product-deep-thought); }
 .ax-text--color-luna-dust { color: var(--color-product-luna-dust); }
+.ax-text--color-sentiment-positive { color: var(--color-sentiment-positive); }
+.ax-text--color-sentiment-negative { color: var(--color-sentiment-negative); }
+.ax-text--color-sentiment-neutral { color: var(--color-sentiment-neutral); }
 
 .ax-text--ellipsis {
   max-width: 100%;


### PR DESCRIPTION
The `Base`-component accepts a limited number of values for the `textColor` property. I want to make use of the `sentiment-negative`, `sentiment-positive` and `sentiment-neutral` colors as well. 