### PR TITLE
NT - required changes for controls

### DIFF
--- a/packages/axiom-components/src/Progress/ProgressButton.js
+++ b/packages/axiom-components/src/Progress/ProgressButton.js
@@ -20,6 +20,8 @@ export default class ProgressButton extends Component {
     isInProgress: PropTypes.bool,
     /** Size of the Button. See Button[size]. */
     size: PropTypes.oneOf(['small', 'medium', 'large']),
+    /** Style of the Button, that affects it's coloring and sizing */
+    style: PropTypes.oneOf(['primary', 'secondary']),
   };
 
   render() {
@@ -27,6 +29,7 @@ export default class ProgressButton extends Component {
       children,
       isInProgress,
       size = Button.defaultProps.size,
+      style = Button.defaultProps.style,
       ...rest
     } = this.props;
 
@@ -38,7 +41,7 @@ export default class ProgressButton extends Component {
       <Button { ...rest }
           active={ isInProgress }
           size={ size }
-          style="primary">
+          style={ style }>
         <div className={ classes }>
           <Cloak
               className="ax-progress-button__content"

--- a/packages/axiom-components/src/Tabset/Tabset.css
+++ b/packages/axiom-components/src/Tabset/Tabset.css
@@ -38,7 +38,7 @@
   padding-bottom: var(--component-border-width);
   border-color: var(--color-theme-border);
   border-bottom-color: transparent;
-  background-color: var(--color-theme-background);
+  background-color: transparent;
   color: var(--color-ui-accent--active);
 }
 


### PR DESCRIPTION
ProgressButton: https://nt-required-changes-for-controls--axiomwija.netlify.com/docs/packages/axiom-components/progress

TabSet: https://nt-required-changes-for-controls--axiomwija.netlify.com/docs/packages/axiom-components/tabset

This is a couple of changes asked for by Christian with regards to the new vizia controls:
- We needed the opportunity to have a progress button styled like a secondary button
- The background of the active tab was supposed to be transparent instead of white