### PR TITLE
feat(UsageHint): Consume width on dropdown context.

### DIFF
--- a/packages/axiom-components/src/UsageHint/UsageHint.js
+++ b/packages/axiom-components/src/UsageHint/UsageHint.js
@@ -15,6 +15,8 @@ export default class UsageHint extends PureComponent {
     children: PropTypes.node,
     position: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
     showArrow: PropTypes.bool,
+    /** Total width of the usageHint dropdown context */
+    width: PropTypes.string,
   };
 
   static defaultProps = {
@@ -24,6 +26,7 @@ export default class UsageHint extends PureComponent {
   render() {
     const {
       children,
+      width,
       ...rest
     } = this.props;
 
@@ -35,7 +38,7 @@ export default class UsageHint extends PureComponent {
           </Link>
         </DropdownTarget>
         <DropdownSource>
-          <DropdownContext>
+          <DropdownContext width={ width }>
             <DropdownContent>
               { children }
             </DropdownContent>


### PR DESCRIPTION
Currently there's no way to change the width of the UsageHint, it takes the default off of the dropdown  context which is `14.5rem`. In the frontend Analytics we would find the addition of this width very useful.

https://kind-hodgkin-6e93e5.netlify.com/docs/packages/axiom-components/usagehint/