### PR TITLE
feat(Ghost): Adds ghost card

### DIFF
--- a/packages/axiom-components/src/CardGraphic/Ghost.css
+++ b/packages/axiom-components/src/CardGraphic/Ghost.css
@@ -1,0 +1,63 @@
+:root {
+  --ghost-width: 8.25rem;
+  --ghost-character-width: 3rem;
+  --ghost-vertical-position: 3.75rem;
+
+  --ghost-light-blue: rgb(199, 230, 245);
+  --ghost-dark-blue: rgb(35, 158, 219);
+  --ghost-gray-dark: rgb(220, 220, 220);
+  --ghost-gray-light: rgb(248, 248, 248);
+
+  --ghost-offset:
+    calc(
+      (var(--ghost-width) / 2) -
+      (var(--ghost-character-width) / 2)
+    );
+}
+
+.ax-ghost {
+  display: block;
+  width: var(--ghost-width);
+  height: 11.625rem;
+}
+
+.ax-ghost__character {
+  transform: translate(var(--ghost-offset), calc(var(--ghost-vertical-position) + 0.5rem));
+  opacity: 0;
+  animation: ghost-appear 1s 0.5s cubic-bezier(0.25, 0.1, 0.25, 1) 1 forwards;
+}
+
+.ax-ghost__eyelid {
+  fill: var(--ghost-light-blue);
+  animation: ghost-blink 8s -5s steps(1, end) infinite forwards;
+}
+
+.ax-ghost__background { fill: var(--ghost-dark-blue); }
+.ax-ghost__body { fill: var(--ghost-light-blue); }
+.ax-ghost__card { fill: var(--ghost-gray-light); }
+.ax-ghost__card-subtitle { fill: var(--ghost-dark-blue); }
+.ax-ghost__card-title { fill: var(--ghost-gray-dark); }
+.ax-ghost__eye { fill: var(--ghost-dark-blue); }
+.ax-ghost__text { fill: var(--ghost-gray-dark); }
+
+@keyframes ghost-appear {
+  to {
+    transform: translate(var(--ghost-offset), var(--ghost-vertical-position));
+    opacity: 1;
+  }
+}
+
+/* 6000ms blinks cycle, 150ms blink, 300ms pause */
+@keyframes ghost-blink {
+  /* blink start: 7400 / 8000 */
+  92.5% { transform: translateY(0.5rem); }
+
+  /* blink end: 7550 / 8000 */
+  94.375% { transform: translateY(0); }
+
+  /* blink start: 7850 / 8000 */
+  98.125% { transform: translateY(0.5rem); }
+
+  /* blink start: 8000 / 8000 */
+  100% { transform: translateY(0); }
+}

--- a/packages/axiom-components/src/CardGraphic/Ghost.js
+++ b/packages/axiom-components/src/CardGraphic/Ghost.js
@@ -1,0 +1,78 @@
+import React, { Component } from 'react';
+import './Ghost.css';
+
+export default class Ghost extends Component {
+
+  render() {
+    return (
+      <svg className="ax-ghost" viewBox="0 0 132 186">
+        <defs>
+          <mask id="hole">
+            <rect fill="white" height="100%" width="100%"/>
+            <circle cx="36" cy="36" r="36" transform="translate(30, 48)"/>
+          </mask>
+        </defs>
+        <circle className="ax-ghost__background" cx="36" cy="36" r="36" transform="translate(30, 48)"/>
+        <g className="ax-ghost__character" transform="translate(42, 68)">
+          <rect
+              className="ax-ghost__body"
+              height="69"
+              rx="24"
+              width="48"
+              x="0"
+              y="0">
+          </rect>
+          <g transform="translate(12, 15)">
+            <circle className="ax-ghost__eye" cx="21" cy="5" r="5"></circle>
+            <circle className="ax-ghost__eye" cx="5" cy="5" r="5"></circle>
+          </g>
+          <g transform="translate(12, 5)">
+            <circle className="ax-ghost__eyelid" cx="5" cy="5" r="5"></circle>
+            <circle className="ax-ghost__eyelid" cx="21" cy="5" r="5"></circle>
+          </g>
+        </g>
+        <g mask="url(#hole)">
+          <rect
+              className="ax-ghost__card"
+              height="100%"
+              rx="3"
+              width="100%"
+              x="0"
+              y="0">
+          </rect>
+          <g className="ax-ghost__text" transform="translate(12, 132)">
+            <g>
+              <rect height="6" width="30" y="0"></rect>
+              <rect height="6" width="42" y="12"></rect>
+              <rect height="6" width="24" y="24"></rect>
+              <rect height="6" width="30" y="36"></rect>
+            </g>
+            <g transform="translate(78, 0)">
+              <rect height="6" width="18" x="12" y="0"></rect>
+              <rect height="6" width="30" x="0" y="12"></rect>
+              <rect height="6" width="12" x="18" y="24"></rect>
+              <rect height="6" width="18" x="12" y="36"></rect>
+            </g>
+          </g>
+          <g transform="translate(30, 18)">
+            <rect
+                className="ax-ghost__card-title"
+                height="6"
+                width="72"
+                x="0"
+                y="0"></rect>
+            <rect
+                className="ax-ghost__card-subtitle"
+                height="6"
+                width="48"
+                x="12"
+                y="12"></rect>
+          </g>
+          <g fill="transparent" transform="translate(30, 48)">
+            <circle cx="36" cy="36" r="36"></circle>
+          </g>
+        </g>
+      </svg>
+    );
+  }
+}

--- a/packages/axiom-components/src/index.js
+++ b/packages/axiom-components/src/index.js
@@ -69,6 +69,7 @@ export { default as DropdownTarget } from './Dropdown/DropdownTarget';
 export { default as EditableLine } from './Editable/EditableLine';
 export { default as EditableTitle } from './Editable/EditableTitle';
 export { default as Form } from './Form/Form';
+export { default as Ghost } from './CardGraphic/Ghost';
 export { default as Grid } from './Grid/Grid';
 export { default as GridCell } from './Grid/GridCell';
 export { default as Heading } from './Typography/Heading';

--- a/site/components/Documentation/Resources/Components.js
+++ b/site/components/Documentation/Resources/Components.js
@@ -18,6 +18,7 @@ import Dialog from './Components/Dialog';
 import Dropdown from './Components/Dropdown';
 import Editable from './Components/Editable';
 import Form from './Components/Form';
+import CardGraphic from './Components/CardGraphic';
 import Grid from './Components/Grid';
 import Icon from './Components/Icon';
 import Image from './Components/Image';
@@ -90,6 +91,10 @@ export default class Documentation extends Component {
             id: 'card',
             name: 'Card',
             Component: Card,
+          }, {
+            id: 'card-graphic',
+            name: 'Card Graphic',
+            Component: CardGraphic,
           }, {
             id: 'cloak',
             name: 'Cloak',

--- a/site/components/Documentation/Resources/Components/CardGraphic.js
+++ b/site/components/Documentation/Resources/Components/CardGraphic.js
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import { Ghost, Grid, GridCell } from '@brandwatch/axiom-components';
+import {
+  DocumentationApi,
+  DocumentationContent,
+  DocumentationShowCase,
+} from '@brandwatch/axiom-documentation-viewer';
+
+export default class Documentation extends Component {
+  render() {
+    return (
+      <DocumentationContent>
+        <DocumentationShowCase centered>
+          <Grid responsive={ false }>
+            <GridCell><Ghost /></GridCell>
+          </Grid>
+        </DocumentationShowCase>
+
+        <DocumentationApi components={ [
+          require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/CardGraphic/Ghost'),
+        ] } />
+      </DocumentationContent>
+    );
+  }
+}


### PR DESCRIPTION
*WARNING - contains animation*

First Card Graphic for use in areas like No Results, there are more designs to follow. Uses CSS and SVG animations, displays ok in Edge and IE11 but doesn't animate. (I ran out of time it's a Funky Friday) 

https://5bdc7bdadd28ef73995b5c69--andyp-axiom.netlify.com/docs/packages/axiom-components/card-graphic

Chrome
<img width="164" alt="chrome-ghost" src="https://user-images.githubusercontent.com/2196085/47927996-caa79b80-debc-11e8-9faf-9839541bfbff.png">

Safari
<img width="154" alt="safari-ghost" src="https://user-images.githubusercontent.com/2196085/47928004-d09d7c80-debc-11e8-93a7-6874f04b38c6.png">

Firefox
<img width="154" alt="firefox-ghost" src="https://user-images.githubusercontent.com/2196085/47928009-d5fac700-debc-11e8-9341-03efb525ae19.png">

Edge
<img width="159" alt="edge-ghost" src="https://user-images.githubusercontent.com/2196085/47928018-dd21d500-debc-11e8-9d4d-a41d6789a71f.png">

IE11
<img width="157" alt="ie11-ghost" src="https://user-images.githubusercontent.com/2196085/47928024-e448e300-debc-11e8-8039-22ec1d0ab357.png">
