### PR TITLE
fix(TextInput): Fix text input size in IE11

### DIFF
--- a/packages/axiom-components/src/Form/InputWrapper.css
+++ b/packages/axiom-components/src/Form/InputWrapper.css
@@ -22,7 +22,7 @@
 .ax-input__wrapper {
   display: flex;
   position: relative;
-  flex: 1 1 0%;
+  flex: 1 1 auto;
   flex-direction: column;
 }
 


### PR DESCRIPTION
Right now TextInputs are rendered with a width of 0px in IE11. Seems like IE11 is behaving differently than Chrome or Firefox when using `flex-basis: 0%`. This change fixes the width in IE11 while the behaviour remains unchanged for Firefox and Chrome.