### PR TITLE
feat(Transition): Adding overflow hidden in y-direction

### DIFF
--- a/packages/axiom-components/src/Transition/Transition.css
+++ b/packages/axiom-components/src/Transition/Transition.css
@@ -1,6 +1,6 @@
 .ax-transition__wrapper  {
   position: relative;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 .ax-transition__item {


### PR DESCRIPTION
This PR adds overflow hidden in y-direction to the Transition component so the scrollbar does not show up. 