### PR TITLE
fix(ContextMenu): set ax-context-menu to full height

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -106,6 +106,7 @@
 }
 
 .ax-context-menu {
+  height: 100%;
   padding: var(--cmp-context-tip-space) 0;
 }
 


### PR DESCRIPTION
Came across this issue trying to add [react-virtualized](https://github.com/bvaughn/react-virtualized) inside a DropdownMenu.

In this case the containing component tries to get it's height from the surrounding container.

For the DropdownMenu that is the div with the `.ax-context-menu`. But it does not set any height, nor max-height, when passing height/max-height to the DropdownMenu, resulting in a height of 0.

By always setting `height: 100%` for `.ax-context-menu`, it takes the full height of it's parent, if it has a height/max-height is set on it.

So this does not interfere with using the Context/DropdownMenu without height nor maxHeight, but allows children to determine the available space.