### PR TITLE
fix(Validate): Make validation on form element dynamic

### DIFF
--- a/packages/axiom-components/package.json
+++ b/packages/axiom-components/package.json
@@ -20,6 +20,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
-    "react-transition-group": "^2.3.0"
+    "react-transition-group": "^2.3.0",
+    "uuid": "^3.3.2"
   }
 }

--- a/packages/axiom-composites/src/ChangePasswordDialog/ChangePasswordDialog.js
+++ b/packages/axiom-composites/src/ChangePasswordDialog/ChangePasswordDialog.js
@@ -13,6 +13,8 @@ import {
   Heading,
   ProgressButton,
   Paragraph,
+  RadioButton,
+  RadioButtonGroup,
 } from '@brandwatch/axiom-components';
 import { translate } from '@brandwatch/axiom-localization';
 import ConfirmPasswordInput from '../FormInputs/ConfirmPasswordInput';
@@ -69,6 +71,7 @@ export default class ChangePasswordDialog extends Component {
       confirmPassword: '',
       currentPassword: '',
       validationError: '',
+      isNewPassword: false,
       newPassword: '',
     };
   }
@@ -97,6 +100,7 @@ export default class ChangePasswordDialog extends Component {
     const {
       confirmPassword,
       currentPassword,
+      isNewPassword,
       newPassword,
       validationError,
     } = this.state;
@@ -124,21 +128,39 @@ export default class ChangePasswordDialog extends Component {
           ) }
 
           <DialogBody>
+            <RadioButtonGroup>
+              <RadioButton
+                  checked={ isNewPassword }
+                  onChange={ () => this.setState({ isNewPassword: true }) }>
+                Set new Password
+              </RadioButton>
+              <RadioButton
+                  checked={ !isNewPassword }
+                  onChange={ () => this.setState({ isNewPassword: false }) }>
+                Don't Set new Password
+              </RadioButton>
+            </RadioButtonGroup>
             <CurrentPasswordInput
                 data-ax-at={ atIds.ChangePassword.currentPassword }
+                disabled={ !isNewPassword }
                 invalid={ isCurrentPasswordInvalid }
                 onChange={ (e) => this.setState({ currentPassword: e.target.value }) }
+                required={ isNewPassword }
                 value={ currentPassword } />
 
             <NewPasswordInput
                 data-ax-at={ atIds.ChangePassword.newPassword }
+                disabled={ !isNewPassword }
                 onChange={ (e) => this.setState({ newPassword: e.target.value }) }
+                required={ isNewPassword }
                 value={ newPassword } />
 
             <ConfirmPasswordInput
                 data-ax-at={ atIds.ChangePassword.confirmPassword }
+                disabled={ !isNewPassword }
                 onChange={ (e) => this.setState({ confirmPassword: e.target.value }) }
                 passwordValue={ newPassword }
+                required={ isNewPassword }
                 value={ confirmPassword } />
 
             <ButtonGroup textRight>

--- a/packages/axiom-composites/src/FormInputs/ConfirmPasswordInput.js
+++ b/packages/axiom-composites/src/FormInputs/ConfirmPasswordInput.js
@@ -35,7 +35,6 @@ export default class ConfirmPasswordInput extends Component {
           error={ () => t('Sorry, your password confirmation doesn\'t match', axiomLanguage) }
           label={ t('Confirm new password', axiomLanguage) }
           patterns={ [(value) => value === passwordValue] }
-          required
           space="x8"
           type="password"
           value={ value } />

--- a/packages/axiom-composites/src/FormInputs/CurrentPasswordInput.js
+++ b/packages/axiom-composites/src/FormInputs/CurrentPasswordInput.js
@@ -29,7 +29,6 @@ export default class CurrentPasswordInput extends Component {
       <TextInput { ...rest }
           invalid={ invalid }
           label={ t('Enter current password', axiomLanguage) }
-          required
           space="x8"
           type="password"
           value={ value } />

--- a/packages/axiom-composites/src/FormInputs/NewPasswordInput.js
+++ b/packages/axiom-composites/src/FormInputs/NewPasswordInput.js
@@ -56,12 +56,13 @@ export default class NewPasswordInput extends Component {
   };
 
   static propTypes = {
+    required: PropTypes.bool,
     value: PropTypes.string.isRequired,
   };
 
   render() {
     const { axiomLanguage } = this.context;
-    const { value, ...rest } = this.props;
+    const { required, value, ...rest } = this.props;
 
     const validations = [{
       error: t('at least 8 characters', axiomLanguage),
@@ -95,8 +96,8 @@ export default class NewPasswordInput extends Component {
       <Validate
           error={ getValidationError }
           key="newPassword"
-          patterns={ validations.map(({ pattern }) => pattern) }
-          required
+          patterns={ required ? validations.map(({ pattern }) => pattern) : [] }
+          required={ required }
           value={ value }>
         { (valid, hasMetRequired, hasMetPattern) => [
           <TextInput { ...rest }


### PR DESCRIPTION
If you change the `required` property of a form input the `Validate` component does not update to reflect the change.

Each form input has a `Validate` wrapper.
A forms `Validates` are managed by the `Validation` component.

A forms `Validates` are now added when in `componentDidUpdate` lifecycle method. Previously `Validation` stored a form `Validators` as an array and used the index to manage removal and edit. `Validators` is now a map with unique ID's.

Example use case, radio button makes `in new folder` input required.

<img width="351" alt="screen shot 2018-12-18 at 01 12 30" src="https://user-images.githubusercontent.com/3940567/50125756-1e4e2880-0262-11e9-8464-66f6b37c7654.png">
