### PR TITLE
feat(DropdownMenu): allow paddingVertical to be configurable

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -107,7 +107,16 @@
 
 .ax-context-menu {
   height: 100%;
-  padding: var(--cmp-context-tip-space) 0;
+}
+
+.ax-context-menu--padding-vertical-none {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.ax-context-menu--padding-vertical-medium {
+  padding-top: var(--cmp-context-tip-space);
+  padding-bottom: var(--cmp-context-tip-space);
 }
 
 .ax-context-menu__item {

--- a/packages/axiom-components/src/Context/ContextMenu.js
+++ b/packages/axiom-components/src/Context/ContextMenu.js
@@ -1,18 +1,30 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import ContextContent from './ContextContent';
 
 export default class ContextMenu extends Component {
   static propTypes = {
     children: PropTypes.node,
+    paddingVertical: PropTypes.oneOf(['none', 'medium']),
+  };
+
+  static defaultProps = {
+    hasFullSeparator: false,
+    paddingVertical: 'medium',
   };
 
   render() {
-    const { children, ...rest } = this.props;
+    const { children, paddingVertical, ...rest } = this.props;
+
+    const classes = classnames(
+      'ax-context-menu',
+      `ax-context-menu--padding-vertical-${paddingVertical}`,
+    );
 
     return (
       <ContextContent { ...rest } padding="none">
-        <div className="ax-context-menu">
+        <div className={ classes }>
           { children }
         </div>
       </ContextContent>

--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
@@ -14,7 +14,7 @@ exports[`ContextMenu renders with defaultProps 1`] = `
     }
   >
     <div
-      className="ax-context-menu"
+      className="ax-context-menu ax-context-menu--padding-vertical-medium"
     >
       <button
         className="ax-context-menu__item"

--- a/packages/axiom-components/src/Dropdown/DropdownMenu.js
+++ b/packages/axiom-components/src/Dropdown/DropdownMenu.js
@@ -6,6 +6,7 @@ export default class DropdownMenu extends Component {
   static propTypes = {
     /** DropdownMenuItems */
     children: PropTypes.node.isRequired,
+    paddingVertical: PropTypes.oneOf(['none', 'medium']),
   };
 
   render() {


### PR DESCRIPTION
When using react-virtualized, the vertical padding of the scrollable container must be defined in a lower component, so the scrollbar spans over the complete container.

This PR allows the vertical padding to be configurable in a dropdown. The default is like before.