### PR TITLE
Adding EllipsisTooltip

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -149,6 +149,7 @@
 
 .ax-context-menu__item-content {
   flex: 1 1 auto;
+  overflow-x: hidden;
 }
 
 .ax-context-menu__item-checkbox {

--- a/packages/axiom-components/src/EllipsisTooltip/EllipsisTooltip.js
+++ b/packages/axiom-components/src/EllipsisTooltip/EllipsisTooltip.js
@@ -1,0 +1,82 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+import Base from '../Base/Base';
+import Tooltip from '../Tooltip/Tooltip';
+import TooltipContent from '../Tooltip/TooltipContent';
+import TooltipContext from '../Tooltip/TooltipContext';
+import TooltipSource from '../Tooltip/TooltipSource';
+import TooltipTarget from '../Tooltip/TooltipTarget';
+
+function elementHasEllipsis(ref = {}) {
+  const { current } = ref;
+  return current && current.scrollWidth > current.clientWidth;
+}
+
+export default class EllipsisTooltip extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    delay: PropTypes.bool,
+    theme: PropTypes.oneOf(['day', 'night']),
+    width: PropTypes.string,
+  };
+
+  static defaultProps = {
+    delay: true,
+    theme: 'night',
+    width: 'auto',
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasEllipsis: false,
+    };
+
+    this.container = React.createRef();
+
+    this.updateTooltipEnabled = this.updateTooltipEnabled.bind(this);
+  }
+
+  updateTooltipEnabled() {
+    const hasEllipsis = elementHasEllipsis(this.container);
+
+    if (this.state.hasEllipsis !== hasEllipsis) {
+      this.setState({ hasEllipsis });
+    }
+  }
+
+  onMouseOver() {
+    this.updateTooltipEnabled();
+  }
+
+  render() {
+    const { children, delay, width, theme, ...rest } = this.props;
+    const { hasEllipsis } = this.state;
+
+    if (!hasEllipsis) {
+      return (
+        <Base baseRef={ this.container } textEllipsis { ...rest } onMouseOver={ this.updateTooltipEnabled }>
+          { children }
+        </Base>
+      );
+    }
+
+    return (
+      <Tooltip delay={ delay } enabled>
+        <TooltipTarget>
+          <Base baseRef={ this.container } textEllipsis { ...rest }>
+            { children }
+          </Base>
+        </TooltipTarget>
+        <TooltipSource theme={ theme } width={ width }>
+          <TooltipContext>
+            <TooltipContent>
+              { children }
+            </TooltipContent>
+          </TooltipContext>
+        </TooltipSource>
+      </Tooltip>
+    );
+  }
+}

--- a/packages/axiom-components/src/index.js
+++ b/packages/axiom-components/src/index.js
@@ -68,6 +68,7 @@ export { default as DropdownSource } from './Dropdown/DropdownSource';
 export { default as DropdownTarget } from './Dropdown/DropdownTarget';
 export { default as EditableLine } from './Editable/EditableLine';
 export { default as EditableTitle } from './Editable/EditableTitle';
+export { default as EllipsisTooltip } from './EllipsisTooltip/EllipsisTooltip';
 export { default as Form } from './Form/Form';
 export { default as Ghost } from './CardGraphic/Ghost';
 export { default as Grid } from './Grid/Grid';

--- a/site/components/Documentation/Resources/Components.js
+++ b/site/components/Documentation/Resources/Components.js
@@ -17,6 +17,7 @@ import DatePicker from './Components/DatePicker';
 import Dialog from './Components/Dialog';
 import Dropdown from './Components/Dropdown';
 import Editable from './Components/Editable';
+import EllipsisTooltip from './Components/EllipsisTooltip';
 import Form from './Components/Form';
 import CardGraphic from './Components/CardGraphic';
 import Grid from './Components/Grid';
@@ -123,6 +124,10 @@ export default class Documentation extends Component {
             id: 'editable',
             name: 'Editable',
             Component: Editable,
+          }, {
+            id: 'ellispsistooltip',
+            name: 'EllipsisTooltip',
+            Component: EllipsisTooltip,
           }, {
             id: 'form',
             name: 'Form',

--- a/site/components/Documentation/Resources/Components/EllipsisTooltip.js
+++ b/site/components/Documentation/Resources/Components/EllipsisTooltip.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import {
+  Grid,
+  GridCell,
+  EllipsisTooltip,
+} from '@brandwatch/axiom-components';
+import {
+  DocumentationApi,
+  DocumentationContent,
+  DocumentationShowCase,
+} from '@brandwatch/axiom-documentation-viewer';
+
+export default class Documentation extends Component {
+  render() {
+    return (
+      <DocumentationContent>
+        <Grid>
+          <GridCell>
+            <DocumentationShowCase centered>
+              <div style={ { width: '100px', display: 'block' } }>
+                <EllipsisTooltip>
+                  Text not wrapped
+                </EllipsisTooltip>
+              </div>
+            </DocumentationShowCase>
+          </GridCell>
+          <GridCell>
+            <DocumentationShowCase centered>
+              <div style={ { width: '100px', display: 'block' } }>
+                <EllipsisTooltip>
+                  Text that will be wrappen having a tooltip on hover
+                </EllipsisTooltip>
+              </div>
+            </DocumentationShowCase>
+          </GridCell>
+        </Grid>
+
+        <DocumentationApi components={ [
+          require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/EllipsisTooltip/EllipsisTooltip'),
+        ] } />
+      </DocumentationContent>
+    );
+  }
+}


### PR DESCRIPTION
Adding a `EllipsisTooltip` that shows a tooltip when the text clipped due to not enough width available.

![image](https://user-images.githubusercontent.com/111471/51251269-37e5ab80-1999-11e9-8195-534f551d82f3.png)

![image](https://user-images.githubusercontent.com/111471/51246924-e551c280-198b-11e9-99b8-3b0c411b8ad3.png)

This is needed for DropdownMenuItems that is forced to have a fixed height (e.g. when used in combination with [react-window](https://github.com/bvaughn/react-window). Long content should be hidden with an ellipsis but but still be shown when hovered over.

[Demo EllipsisTooltip](https://brandwatch-axiom-tomru.netlify.com/docs/packages/axiom-components/ellispsistooltip)
[Demo inside Dropdown (lower right one)](https://brandwatch-axiom-tomru.netlify.com/docs/packages/axiom-components/dropdown)