### PR TITLE
fix(ContextMenuItem): mouse events do not fire in firefox

### DIFF
--- a/packages/axiom-components/src/Context/ContextMenuItem.js
+++ b/packages/axiom-components/src/Context/ContextMenuItem.js
@@ -36,7 +36,7 @@ export default class ContextMenuItem extends Component {
 
     return (
       <Base { ...rest } { ...{ [contextMenuItemSelector]: true } }
-          Component="button"
+          aria-role="Menuitem"
           className={ classes }
           disabled={ disabled }
           onClick={ onClick }

--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
@@ -16,7 +16,8 @@ exports[`ContextMenu renders with defaultProps 1`] = `
     <div
       className="ax-context-menu ax-context-menu--padding-vertical-medium"
     >
-      <button
+      <div
+        aria-role="Menuitem"
         className="ax-context-menu__item"
         data-ax-context-menu-item={true}
       >
@@ -25,7 +26,7 @@ exports[`ContextMenu renders with defaultProps 1`] = `
         >
           Lorem ipsum
         </div>
-      </button>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ContextMenuItem renders with custom icon 1`] = `
-<button
+<div
+  aria-role="Menuitem"
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
 >
@@ -29,11 +30,12 @@ exports[`ContextMenuItem renders with custom icon 1`] = `
       viewBox="0 0 16 16"
     />
   </div>
-</button>
+</div>
 `;
 
 exports[`ContextMenuItem renders with defaultProps 1`] = `
-<button
+<div
+  aria-role="Menuitem"
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
 >
@@ -42,11 +44,12 @@ exports[`ContextMenuItem renders with defaultProps 1`] = `
   >
     Lorem ipsum
   </div>
-</button>
+</div>
 `;
 
 exports[`ContextMenuItem renders with disabled 1`] = `
-<button
+<div
+  aria-role="Menuitem"
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
   disabled={true}
@@ -56,11 +59,12 @@ exports[`ContextMenuItem renders with disabled 1`] = `
   >
     Lorem ipsum
   </div>
-</button>
+</div>
 `;
 
 exports[`ContextMenuItem renders with multiSelect 1`] = `
-<button
+<div
+  aria-role="Menuitem"
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
 >
@@ -86,11 +90,12 @@ exports[`ContextMenuItem renders with multiSelect 1`] = `
   >
     Lorem ipsum
   </div>
-</button>
+</div>
 `;
 
 exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
-<button
+<div
+  aria-role="Menuitem"
   className="ax-context-menu__item ax-context-menu__item--selected ax-text--strong"
   data-ax-context-menu-item={true}
 >
@@ -116,11 +121,12 @@ exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
   >
     Lorem ipsum
   </div>
-</button>
+</div>
 `;
 
 exports[`ContextMenuItem renders with multiSelect and title 1`] = `
-<button
+<div
+  aria-role="Menuitem"
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
   title="Lorem ipsum dolor sit amet"
@@ -147,11 +153,12 @@ exports[`ContextMenuItem renders with multiSelect and title 1`] = `
   >
     Lorem ipsum
   </div>
-</button>
+</div>
 `;
 
 exports[`ContextMenuItem renders with selected 1`] = `
-<button
+<div
+  aria-role="Menuitem"
   className="ax-context-menu__item ax-context-menu__item--selected ax-text--strong"
   data-ax-context-menu-item={true}
 >
@@ -179,11 +186,12 @@ exports[`ContextMenuItem renders with selected 1`] = `
       viewBox="0 0 16 16"
     />
   </div>
-</button>
+</div>
 `;
 
 exports[`ContextMenuItem renders with title 1`] = `
-<button
+<div
+  aria-role="Menuitem"
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
   title="Lorem ipsum dolor sit amet"
@@ -193,5 +201,5 @@ exports[`ContextMenuItem renders with title 1`] = `
   >
     Lorem ipsum
   </div>
-</button>
+</div>
 `;


### PR DESCRIPTION
A [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1084196) in firefox cause mouse events to not fire below a button element causing the EllipseTooltip to not work inside a DropdownContextMenuItem in Firefox.

Generally it makes sense to use a button for a ContextMenuItem as long as it is a simple entry you can click.

But there are at least two use-cases that allow some sort of interaction inside the ContextMenuItem:

1. checkbox to activate ContextMenuItem
2. showing a tooltip on a truncated named (using the EllipseTooltip)

Though the definition of the button does [permit interactive content](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).

As there are use-cases where there is interaction in the ContextMenuItem it is reasonable to change the element of ContextMenuItem to a div and set the ARIA role to `Menuitem` instead to fix that bug.