### PR TITLE
AX-121 publish es modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -37,7 +37,13 @@
       plugins: [
         "@brandwatch/babel-plugin-transform-svg-axiom",
         "@brandwatch/babel-plugin-axiom-imports",
-        "transform-es2015-modules-commonjs"
+        "transform-es2015-modules-commonjs",
+      ]
+    },
+    "production-esm": {
+      plugins: [
+        "@brandwatch/babel-plugin-transform-svg-axiom",
+        "@brandwatch/babel-plugin-axiom-imports",
       ]
     },
     "test": {

--- a/.babelrc
+++ b/.babelrc
@@ -33,7 +33,7 @@
         "transform-react-remove-prop-types"
       ]
     },
-    "production": {
+    "production-cjs": {
       plugins: [
         "@brandwatch/babel-plugin-transform-svg-axiom",
         "@brandwatch/babel-plugin-axiom-imports",

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
-**/dist/*
+**/dist-cjs/*
+**/dist-esm/*
 **/node_modules/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-dist
+dist-cjs
 public
 node_modules
 lerna-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist-cjs
+dist-esm
 public
 node_modules
 lerna-debug.log

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,3 @@
-**/dist/*
+**/dist-cjs/*
+**/dist-esm/*
 **/node_modules/*

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
   },
   "npmClient": "yarn",
   "packages": [
-    "packages/*"
+    "packages/axiom-*"
   ],
   "useWorkspaces": true,
   "version": "independent"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
   "scripts": {
-    "build:packages": "NODE_ENV=production BABEL_ENV=production bash ./scripts/build_packages.sh",
+    "build:packages": "NODE_ENV=production bash ./scripts/build_packages.sh",
     "build:site": "NODE_ENV=production BABEL_ENV=static webpack --config webpack.static.config.js",
-    "ci:setup": "NODE_ENV=production BABEL_ENV=test bash ./scripts/ci_setup.sh",
+    "ci:setup": "NODE_ENV=production bash ./scripts/ci_setup.sh",
     "ci:test": "TZ=utc jest ./packages/**/dist --config .jest.ci.json",
     "lint": "yarn run lint:js && yarn run lint:css",
     "lint:css": "stylelint 'packages/**/*.css' 'site/**/*.css'",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "build:packages": "NODE_ENV=production bash ./scripts/build_packages.sh",
     "build:site": "NODE_ENV=production BABEL_ENV=static webpack --config webpack.static.config.js",
     "ci:setup": "NODE_ENV=production bash ./scripts/ci_setup.sh",
-    "ci:test": "TZ=utc jest ./packages/**/dist --config .jest.ci.json",
+    "ci:test": "TZ=utc jest ./packages/**/dist-cjs/ --config .jest.ci.json",
     "lint": "yarn run lint:js && yarn run lint:css",
     "lint:css": "stylelint 'packages/**/*.css' 'site/**/*.css'",
     "lint:js": "eslint --config .eslintrc packages site",
@@ -13,7 +13,7 @@
     "publish:site": "bash ./scripts/publish_site.sh",
     "start": "bash ./scripts/start_development.sh",
     "postinstall": "lerna run prepublish && lerna run prepare",
-    "test": "TZ=utc BABEL_ENV=test jest ./packages --config .jest.json"
+    "test": "TZ=utc BABEL_ENV=test jest ./packages/**/dist-cjs/ --config .jest.json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/axiom-automation-testing/package.json
+++ b/packages/axiom-automation-testing/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.7",
   "description": "Brandwatch Axiom - Automation testing",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-automation-testing/package.json
+++ b/packages/axiom-automation-testing/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-automation-testing",
   "version": "0.0.7",
   "description": "Brandwatch Axiom - Automation testing",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-charts/package.json
+++ b/packages/axiom-charts/package.json
@@ -3,6 +3,8 @@
   "version": "5.1.2",
   "description": "Brandwatch Axiom - Charting components",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-charts/package.json
+++ b/packages/axiom-charts/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-charts",
   "version": "5.1.2",
   "description": "Brandwatch Axiom - Charting components",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-components/package.json
+++ b/packages/axiom-components/package.json
@@ -3,6 +3,8 @@
   "version": "5.11.1",
   "description": "Brandwatch Axiom - Components",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-components/package.json
+++ b/packages/axiom-components/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-components",
   "version": "5.11.1",
   "description": "Brandwatch Axiom - Components",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-composites/package.json
+++ b/packages/axiom-composites/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.91",
   "description": "Brandwatch Axiom - Composites",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-composites/package.json
+++ b/packages/axiom-composites/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-composites",
   "version": "0.0.91",
   "description": "Brandwatch Axiom - Composites",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-documentation-loader/package.json
+++ b/packages/axiom-documentation-loader/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-documentation-loader",
   "version": "0.0.4",
   "description": "Brandwatch Axiom - Documentation webpack loader",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-documentation-loader/package.json
+++ b/packages/axiom-documentation-loader/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.4",
   "description": "Brandwatch Axiom - Documentation webpack loader",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-documentation-viewer/package.json
+++ b/packages/axiom-documentation-viewer/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-documentation-viewer",
   "version": "0.1.79",
   "description": "Brandwatch Axiom - Documentation Viewer",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-documentation-viewer/package.json
+++ b/packages/axiom-documentation-viewer/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.79",
   "description": "Brandwatch Axiom - Documentation Viewer",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-formatting/package.json
+++ b/packages/axiom-formatting/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-formatting",
   "version": "0.0.5",
   "description": "Brandwatch Axiom - Formatting",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-formatting/package.json
+++ b/packages/axiom-formatting/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.5",
   "description": "Brandwatch Axiom - Formatting",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-localization/package.json
+++ b/packages/axiom-localization/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-localization",
   "version": "0.0.4",
   "description": "Brandwatch Axiom - Localization",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-localization/package.json
+++ b/packages/axiom-localization/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.4",
   "description": "Brandwatch Axiom - Localization",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-materials/package.json
+++ b/packages/axiom-materials/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-materials",
   "version": "1.11.1",
   "description": "Brandwatch Axiom - Materials",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-materials/package.json
+++ b/packages/axiom-materials/package.json
@@ -3,6 +3,8 @@
   "version": "1.11.1",
   "description": "Brandwatch Axiom - Materials",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-utils/package.json
+++ b/packages/axiom-utils/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.17",
   "description": "Brandwatch Axiom - Utils",
   "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "sideEffects": false,
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/axiom-utils/package.json
+++ b/packages/axiom-utils/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/axiom-utils",
   "version": "0.1.17",
   "description": "Brandwatch Axiom - Utils",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-axiom-imports/package.json
+++ b/packages/babel-plugin-axiom-imports/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/babel-plugin-axiom-imports",
   "version": "0.2.3",
   "description": "Brandwatch Axiom - Babel plugin to transform Axiom imports",
-  "main": "dist/babel-plugin-axiom-imports.js",
+  "main": "dist-cjs/babel-plugin-axiom-imports.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-axiom-imports/src/__snapshots__/babel-plugin-axiom-imports.test.js.snap
+++ b/packages/babel-plugin-axiom-imports/src/__snapshots__/babel-plugin-axiom-imports.test.js.snap
@@ -3,23 +3,23 @@
 exports[`babelPluginAxiom aliased imports 1`] = `
 "'use strict';
 
-var _findComponent = require('@brandwatch/axiom-utils/dist/findComponent');
+var _findComponent = require('@brandwatch/axiom-utils/dist-cjs/findComponent');
 
 var _findComponent2 = _interopRequireDefault(_findComponent);
 
-var _DotPlotChart = require('@brandwatch/axiom-charts/dist/DotPlotChart/DotPlotChart');
+var _DotPlotChart = require('@brandwatch/axiom-charts/dist-cjs/DotPlotChart/DotPlotChart');
 
 var _DotPlotChart2 = _interopRequireDefault(_DotPlotChart);
 
-var _Base = require('@brandwatch/axiom-components/dist/Base/Base');
+var _Base = require('@brandwatch/axiom-components/dist-cjs/Base/Base');
 
 var _Base2 = _interopRequireDefault(_Base);
 
-var _longDate = require('@brandwatch/axiom-formatting/dist/longDate');
+var _longDate = require('@brandwatch/axiom-formatting/dist-cjs/longDate');
 
 var _longDate2 = _interopRequireDefault(_longDate);
 
-var _shortDate = require('@brandwatch/axiom-formatting/dist/shortDate');
+var _shortDate = require('@brandwatch/axiom-formatting/dist-cjs/shortDate');
 
 var _shortDate2 = _interopRequireDefault(_shortDate);
 
@@ -61,27 +61,27 @@ console.log(materials.colors); /* eslint-disable no-console */"
 exports[`babelPluginAxiom destructured imports 1`] = `
 "'use strict';
 
-var _colors = require('@brandwatch/axiom-materials/dist/colors');
+var _colors = require('@brandwatch/axiom-materials/dist-cjs/colors');
 
 var _ = _interopRequireWildcard(_colors);
 
-var _findComponent = require('@brandwatch/axiom-utils/dist/findComponent');
+var _findComponent = require('@brandwatch/axiom-utils/dist-cjs/findComponent');
 
 var _findComponent2 = _interopRequireDefault(_findComponent);
 
-var _DotPlotChart = require('@brandwatch/axiom-charts/dist/DotPlotChart/DotPlotChart');
+var _DotPlotChart = require('@brandwatch/axiom-charts/dist-cjs/DotPlotChart/DotPlotChart');
 
 var _DotPlotChart2 = _interopRequireDefault(_DotPlotChart);
 
-var _Base = require('@brandwatch/axiom-components/dist/Base/Base');
+var _Base = require('@brandwatch/axiom-components/dist-cjs/Base/Base');
 
 var _Base2 = _interopRequireDefault(_Base);
 
-var _longDate = require('@brandwatch/axiom-formatting/dist/longDate');
+var _longDate = require('@brandwatch/axiom-formatting/dist-cjs/longDate');
 
 var _longDate2 = _interopRequireDefault(_longDate);
 
-var _shortDate = require('@brandwatch/axiom-formatting/dist/shortDate');
+var _shortDate = require('@brandwatch/axiom-formatting/dist-cjs/shortDate');
 
 var _shortDate2 = _interopRequireDefault(_shortDate);
 
@@ -114,7 +114,7 @@ console.log(_axiomMaterials2.default.colors); /* eslint-disable no-console */"
 exports[`babelPluginAxiom property access 1`] = `
 "'use strict';
 
-var _colors = require('@brandwatch/axiom-materials/dist/colors');
+var _colors = require('@brandwatch/axiom-materials/dist-cjs/colors');
 
 var _ = _interopRequireWildcard(_colors);
 
@@ -129,7 +129,7 @@ console.log(_['foo-bar']);"
 exports[`babelPluginAxiom scoped imports 1`] = `
 "'use strict';
 
-var _findComponent = require('@brandwatch/axiom-utils/dist/findComponent');
+var _findComponent = require('@brandwatch/axiom-utils/dist-cjs/findComponent');
 
 var _findComponent2 = _interopRequireDefault(_findComponent);
 
@@ -150,7 +150,7 @@ bar();"
 exports[`babelPluginAxiom used as defaults 1`] = `
 "'use strict';
 
-var _colors = require('@brandwatch/axiom-materials/dist/colors');
+var _colors = require('@brandwatch/axiom-materials/dist-cjs/colors');
 
 var _ = _interopRequireWildcard(_colors);
 

--- a/packages/babel-plugin-axiom-imports/src/resolve-import.js
+++ b/packages/babel-plugin-axiom-imports/src/resolve-import.js
@@ -39,9 +39,9 @@ const exportsList = supportedAxiomPackages.reduce((memo, packageName) => {
           return importList[spec.local.name] = node.source.value;
         case 'ExportSpecifier':
           if (spec.local.name === spec.exported.name && importList[spec.local.name]) {
-            memo[packageName][spec.local.name] = [path.join(`${packageName}/dist`, importList[spec.local.name]), '*'];
+            memo[packageName][spec.local.name] = [path.join(`${packageName}/dist-cjs`, importList[spec.local.name]), '*'];
           } else {
-            memo[packageName][spec.exported.name] = [path.join(`${packageName}/dist`, node.source.value), 'default'];
+            memo[packageName][spec.exported.name] = [path.join(`${packageName}/dist-cjs`, node.source.value), 'default'];
           }
         }
       });

--- a/packages/babel-plugin-transform-svg-axiom/package.json
+++ b/packages/babel-plugin-transform-svg-axiom/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/babel-plugin-transform-svg-axiom",
   "version": "0.1.1",
   "description": "Brandwatch Axiom - Babel plugin to inline SVG files",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/eslint-config-axiom/package.json
+++ b/packages/eslint-config-axiom/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/eslint-config-axiom",
   "version": "0.0.4",
   "description": "Brandwatch Axiom - eslint config",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/packages/stylelint-config-axiom/package.json
+++ b/packages/stylelint-config-axiom/package.json
@@ -2,7 +2,7 @@
   "name": "@brandwatch/stylelint-config-axiom",
   "version": "0.2.1",
   "description": "Brandwatch Axiom - stylelint config",
-  "main": "dist/index.js",
+  "main": "dist-cjs/index.js",
   "license": "UNLICENSED",
   "publishConfig": {
     "access": "public"

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -2,9 +2,18 @@
 set -e
 
 DIST_CJS=dist-cjs
+DIST_ESM=dist-esm
 
-npx lerna exec --parallel -- rm -rf $DIST_CJS
+CJS_ONLY_PLUGIN_SCOPE="@brandwatch/+(babel*|*lint-config*)"
+
+# CommonJS build
 npx lerna exec --parallel -- rsync -a --prune-empty-dirs --exclude '__snapshots__/*' --exclude '*.test.js' src/* $DIST_CJS
 npx lerna exec --parallel -- BABEL_ENV=production-cjs npx babel $DIST_CJS -d $DIST_CJS
 
 npx postcss packages/**/$DIST_CJS/**/*.css --config ./postcss.prod.config.js --replace --verbose
+
+# ESM build
+npx lerna exec --parallel --ignore $CJS_ONLY_PLUGIN_SCOPE -- rsync -a --prune-empty-dirs --exclude '__snapshots__/*' --exclude '*.test.js' src/* $DIST_ESM
+npx lerna exec --parallel --ignore $CJS_ONLY_PLUGIN_SCOPE -- BABEL_ENV=production-esm npx babel $DIST_ESM -d $DIST_ESM
+
+npx postcss packages/**/$DIST_ESM/**/*.css --config ./postcss.prod.config.js --replace --verbose

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -3,6 +3,6 @@ set -e
 
 npx lerna exec --parallel -- rm -rf dist
 npx lerna exec --parallel -- rsync -a --prune-empty-dirs --exclude '__snapshots__/*' --exclude '*.test.js' src/* dist
-npx lerna exec --parallel -- npx babel dist -d dist
+npx lerna exec --parallel -- BABEL_ENV=production npx babel dist -d dist
 
 npx postcss packages/**/dist/**/*.css --config ./postcss.prod.config.js --replace --verbose

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -e
 
-npx lerna exec --parallel -- rm -rf dist
-npx lerna exec --parallel -- rsync -a --prune-empty-dirs --exclude '__snapshots__/*' --exclude '*.test.js' src/* dist
-npx lerna exec --parallel -- BABEL_ENV=production npx babel dist -d dist
+DIST_CJS=dist-cjs
 
-npx postcss packages/**/dist/**/*.css --config ./postcss.prod.config.js --replace --verbose
+npx lerna exec --parallel -- rm -rf $DIST_CJS
+npx lerna exec --parallel -- rsync -a --prune-empty-dirs --exclude '__snapshots__/*' --exclude '*.test.js' src/* $DIST_CJS
+npx lerna exec --parallel -- BABEL_ENV=production-cjs npx babel $DIST_CJS -d $DIST_CJS
+
+npx postcss packages/**/$DIST_CJS/**/*.css --config ./postcss.prod.config.js --replace --verbose

--- a/scripts/ci_setup.sh
+++ b/scripts/ci_setup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-npx lerna exec --parallel -- rm -rf dist
-npx lerna exec --parallel -- rsync -a --prune-empty-dirs src/* dist
-npx lerna exec --parallel -- BABEL_ENV=test npx babel dist -d dist
+DIST_CJS=dist-cjs
+
+npx lerna exec --parallel -- rm -rf $DIST_CJS
+npx lerna exec --parallel -- rsync -a --prune-empty-dirs src/* $DIST_CJS
+npx lerna exec --parallel -- BABEL_ENV=test npx babel $DIST_CJS -d $DIST_CJS

--- a/scripts/ci_setup.sh
+++ b/scripts/ci_setup.sh
@@ -3,4 +3,4 @@ set -e
 
 npx lerna exec --parallel -- rm -rf dist
 npx lerna exec --parallel -- rsync -a --prune-empty-dirs src/* dist
-npx lerna exec --parallel -- npx babel dist -d dist
+npx lerna exec --parallel -- BABEL_ENV=test npx babel dist -d dist

--- a/scripts/start_development.sh
+++ b/scripts/start_development.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-npx lerna exec --parallel -- "rm -rf dist && ln -s src dist"
+npx lerna exec --parallel -- "rm -rf dist-cjs dist-esm && ln -s src dist"
 npx webpack-dev-server


### PR DESCRIPTION
👷 

This PR adds es modules along to the common js build. This enables bundlers like webpack, rollup etc. to do [tree-shaking](https://webpack.js.org/guides/tree-shaking/) and remove unused code from the build.

The approach is naive in the sense that it creates two directories, `dist-cjs` and `dist-esm` in which the relevant module format is built via babel separately. The `main` and `module` in the relevant `package.json` will point to the relevant `index.js`.

This is only applied to modules that are relevant to a consumer, i.e. `babel-plugin-axiom-imports`, `babel-plugin-transform-svg-axiom`, `eslint-config-axiom` and `stylelint-config-axiom` will still only have a common js build.

I'd be happy to get some feedback already

### TODO
- [ ] measure build improvements in analytics


