### PR TITLE
fix(ContextMenuItem): revert "mouse events do not fire in firefox"

### DIFF
--- a/packages/axiom-components/src/Context/ContextMenuItem.js
+++ b/packages/axiom-components/src/Context/ContextMenuItem.js
@@ -36,7 +36,7 @@ export default class ContextMenuItem extends Component {
 
     return (
       <Base { ...rest } { ...{ [contextMenuItemSelector]: true } }
-          aria-role="Menuitem"
+          Component="button"
           className={ classes }
           disabled={ disabled }
           onClick={ onClick }

--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
@@ -16,8 +16,7 @@ exports[`ContextMenu renders with defaultProps 1`] = `
     <div
       className="ax-context-menu ax-context-menu--padding-vertical-medium"
     >
-      <div
-        aria-role="Menuitem"
+      <button
         className="ax-context-menu__item"
         data-ax-context-menu-item={true}
       >
@@ -26,7 +25,7 @@ exports[`ContextMenu renders with defaultProps 1`] = `
         >
           Lorem ipsum
         </div>
-      </div>
+      </button>
     </div>
   </div>
 </div>

--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ContextMenuItem renders with custom icon 1`] = `
-<div
-  aria-role="Menuitem"
+<button
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
 >
@@ -30,12 +29,11 @@ exports[`ContextMenuItem renders with custom icon 1`] = `
       viewBox="0 0 16 16"
     />
   </div>
-</div>
+</button>
 `;
 
 exports[`ContextMenuItem renders with defaultProps 1`] = `
-<div
-  aria-role="Menuitem"
+<button
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
 >
@@ -44,12 +42,11 @@ exports[`ContextMenuItem renders with defaultProps 1`] = `
   >
     Lorem ipsum
   </div>
-</div>
+</button>
 `;
 
 exports[`ContextMenuItem renders with disabled 1`] = `
-<div
-  aria-role="Menuitem"
+<button
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
   disabled={true}
@@ -59,12 +56,11 @@ exports[`ContextMenuItem renders with disabled 1`] = `
   >
     Lorem ipsum
   </div>
-</div>
+</button>
 `;
 
 exports[`ContextMenuItem renders with multiSelect 1`] = `
-<div
-  aria-role="Menuitem"
+<button
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
 >
@@ -90,12 +86,11 @@ exports[`ContextMenuItem renders with multiSelect 1`] = `
   >
     Lorem ipsum
   </div>
-</div>
+</button>
 `;
 
 exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
-<div
-  aria-role="Menuitem"
+<button
   className="ax-context-menu__item ax-context-menu__item--selected ax-text--strong"
   data-ax-context-menu-item={true}
 >
@@ -121,12 +116,11 @@ exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
   >
     Lorem ipsum
   </div>
-</div>
+</button>
 `;
 
 exports[`ContextMenuItem renders with multiSelect and title 1`] = `
-<div
-  aria-role="Menuitem"
+<button
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
   title="Lorem ipsum dolor sit amet"
@@ -153,12 +147,11 @@ exports[`ContextMenuItem renders with multiSelect and title 1`] = `
   >
     Lorem ipsum
   </div>
-</div>
+</button>
 `;
 
 exports[`ContextMenuItem renders with selected 1`] = `
-<div
-  aria-role="Menuitem"
+<button
   className="ax-context-menu__item ax-context-menu__item--selected ax-text--strong"
   data-ax-context-menu-item={true}
 >
@@ -186,12 +179,11 @@ exports[`ContextMenuItem renders with selected 1`] = `
       viewBox="0 0 16 16"
     />
   </div>
-</div>
+</button>
 `;
 
 exports[`ContextMenuItem renders with title 1`] = `
-<div
-  aria-role="Menuitem"
+<button
   className="ax-context-menu__item"
   data-ax-context-menu-item={true}
   title="Lorem ipsum dolor sit amet"
@@ -201,5 +193,5 @@ exports[`ContextMenuItem renders with title 1`] = `
   >
     Lorem ipsum
   </div>
-</div>
+</button>
 `;


### PR DESCRIPTION
This reverts commit 7590b94de13e911ccae7480e1dded81086a79311.

https://github.com/BrandwatchLtd/axiom/pull/705 had a knock on effect on `ContextMenuItem` when used directly which I missed.

The applied change causes the highlight to not work anymore and shows a cursor instead of a pointer.

Reverting for now until we find a better solution